### PR TITLE
Parse in xml to other xml content type

### DIFF
--- a/lib/faraday/parse.rb
+++ b/lib/faraday/parse.rb
@@ -13,7 +13,7 @@ module Faraday
           case response[:response_headers].values_at('content-type', 'Content-Type').first
           when /\/json/
             parse_json(response[:body])
-          when /\/xml/
+          when /\/.*xml/
             parse_xml(response[:body])
           else
             ''

--- a/test/parse_test.rb
+++ b/test/parse_test.rb
@@ -85,6 +85,19 @@ class ParseTest < Test::Unit::TestCase
       end
     end
 
+    context "when there is a ATOM body" do
+      setup do
+        @stubs.get('/me') {[200, {'content-type' => 'application/atom+xml; charset=utf-8'}, '<user><name>Erik Michaels-Ober</name><username>sferik</username></user>']}
+      end
+
+      should 'parse the body as XML' do
+        me = @conn.get("/me").body['user']
+        assert me.is_a?(Hash)
+        assert_equal 'Erik Michaels-Ober', me['name']
+        assert_equal 'sferik', me['username']
+      end
+    end
+
     context "when the XML body is empty" do
       setup do
         @stubs.get('/me') {[200, {'content-type' => 'application/xml; charset=utf-8'}, ""]}


### PR DESCRIPTION
There are not only the */xml to be parse by xml. By example the appplication/atom+xml

This patch allow a lot of more content-type.

Maybe a solution to force XML or JSON parsing  can be better. Like previous version 0.1.7 when Json parsing and Xml parsing was separate.
