### PR TITLE
Bumped Faraday dependency to 0.7.0

### DIFF
--- a/faraday_middleware.gemspec
+++ b/faraday_middleware.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new('>= 1.3.6') if s.respond_to? :required_rubygems_version=
 
-  s.add_runtime_dependency('faraday', '~> 0.6.0')
+  s.add_runtime_dependency('faraday', '~> 0.7.0')
   s.add_development_dependency('rake', '~> 0.8')
   s.add_development_dependency('rspec', '~> 2.5')
   s.add_development_dependency('simplecov', '~> 0.4')


### PR DESCRIPTION
I tried using Faraday 0.7.0 in one of my apps, but couldn't because faraday_middleware depends on 0.6.0.
