### PR TITLE
Loosen up the Faraday gem version requirement

### DIFF
--- a/faraday_middleware.gemspec
+++ b/faraday_middleware.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.required_rubygems_version = Gem::Requirement.new('>= 1.3.6')
 
-  gem.add_runtime_dependency 'faraday', '~> 0.6.0'
+  gem.add_runtime_dependency 'faraday', '~> 0.6'
   gem.add_development_dependency 'rake', '~> 0.8'
   gem.add_development_dependency 'rspec', '~> 2.6'
   gem.add_development_dependency 'simplecov', '~> 0.4'


### PR DESCRIPTION
I saw that there's already another similar pull request on this. This one is slightly different though, bear with me. :)

Since Faraday is still under rapid development, restricting Faraday to the 0.6.x version range range isn't, from my perspective, a good idea. I loosed up the gem requirement so that faraday_middleware with work for any version of Faraday >= 0.6.0 and < 1.0.0.

I've tried bundling and running this with my fork of oauth2 which also allows for Faraday 0.7 and all the spec pass.
