### PR TITLE
Body Parameters

### DIFF
--- a/lib/faraday/request/oauth.rb
+++ b/lib/faraday/request/oauth.rb
@@ -6,12 +6,8 @@ module Faraday
 
     def call(env)
       params = env[:body] || {}
-      
-      con = false
-      env[:request_headers].each do |k,v|
-        con = true if v.to_s.downcase == "application/x-www-form-urlencoded"
-      end
-      signature_params = con ? params.reject{ |k,v| v.respond_to?(:content_type) } : {}
+
+      signature_params = env[:method] == :post && env[:content_type] == "application/x-www-form-urlencoded" ? params.reject{ |k,v| v.respond_to?(:content_type) } : {}
 
       header = SimpleOAuth::Header.new(env[:method], env[:url], signature_params, @options)
 

--- a/spec/oauth_spec.rb
+++ b/spec/oauth_spec.rb
@@ -16,7 +16,7 @@ describe Faraday::Request::OAuth do
     let(:oauth) { Faraday::Request::OAuth.new(DummyApp.new, config) }
 
     let(:env) do
-      { :request_headers => {}, :url => Addressable::URI.parse('http://www.github.com') }
+      { :request_headers => {}, :url => Addressable::URI.parse('http://www.github.com'), :body => { :test => "test" } }
     end
 
     it 'should add the access token to the header' do


### PR DESCRIPTION
While tracking down a problem from the twitter library I discovered that this library was passing over all non media parameters to simple_oauth to include in the signature. According to the specification this should only be done for "application/x-www-form-urlencoded" types on POST requests. It should now generate the signature without the body unless those parameters are met.

I added a non-media body parameter to the test case to ensure that nothing absolutely breaks, however I am uncertain how I'd write an integration test for this, and there were none for it or OAuth2 integration already.

Anywho, I compiled this with two or three other dependent libraries as well to ensure that it didn't break any of them.

If there's anything I missed, then let me know and I'll be happy to take a look at it.
