### PR TITLE
Changing the oauth request body function

### DIFF
--- a/lib/faraday/request/oauth.rb
+++ b/lib/faraday/request/oauth.rb
@@ -6,8 +6,9 @@ module Faraday
 
     def call(env)
       params = env[:body] || {}
+      signature_params = params
 
-      signature_params = params.reject{ |k,v| v.respond_to?(:content_type) }
+      params.map{ |k,v| signature_params = {} if v.respond_to?(:content_type) }
 
       header = SimpleOAuth::Header.new(env[:method], env[:url], signature_params, @options)
 


### PR DESCRIPTION
Alright, so after reviewing my last patch, I went back to the oauth specification, but found that it did say that the body should only be encoded under the circumstance caught in the last patch. However, it appears that twitter and facebook (before they pushed everyone to OAuth 2) have the entire body encoded except when the body contains a file to upload. While this isn't to specification it is more secure, which I'm sure is why they did it that way. So I rewrote it again to follow that protocol.

Perhaps later this should be rewritten again to allow for both with an option, defaulting to one way or another. However this should rectify the current issues.
