### PR TITLE
let rashify inherit from mashify

### DIFF
--- a/lib/faraday/response/rashify.rb
+++ b/lib/faraday/response/rashify.rb
@@ -1,19 +1,9 @@
 require 'faraday'
 
 module Faraday
-  class Response::Rashify < Response::Middleware
-    dependency 'hashie/mash'
+  class Response::Rashify < Response::Mashify
     dependency 'rash'
 
-    def parse(body)
-      case body
-      when Hash
-        ::Hashie::Rash.new(body)
-      when Array
-        body.map { |item| item.is_a?(Hash) ? ::Hashie::Rash.new(item) : item }
-      else
-        body
-      end
-    end
+    self.mash_class = ::Hashie::Rash
   end
 end


### PR DESCRIPTION
I was looking at Mashify and Rashify and realized their `parse` methods were identical.  Since Response::Mashify allows assignment of the `mash_class`, we can simple inherit from Mashify and assign the `mash_class` appropriately.  All tests still pass with 1.8.7 and 1.9.2
