### PR TITLE
Add HTML Parsing Middleware

### DIFF
--- a/faraday_middleware.gemspec
+++ b/faraday_middleware.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec', '~> 2.6'
   gem.add_development_dependency 'simple_oauth', '~> 0.1'
   gem.add_development_dependency 'rack-cache', '~> 1.1'
+  gem.add_development_dependency 'nokogiri', '~> 1.5.0'
   gem.authors = ["Erik Michaels-Ober", "Wynn Netherland"]
   gem.description = %q{Various middleware for Faraday}
   gem.email = ['sferik@gmail.com', 'wynn.netherland@gmail.com']

--- a/lib/faraday_middleware/response/parse_html.rb
+++ b/lib/faraday_middleware/response/parse_html.rb
@@ -1,0 +1,11 @@
+require 'faraday_middleware/response_middleware'
+
+module FaradayMiddleware
+  class ParseHtml < FaradayMiddleware::ResponseMiddleware
+    dependency 'nokogiri'
+
+    define_parser { |body|
+      Nokogiri::HTML body
+    }
+  end
+end

--- a/spec/parse_html_spec.rb
+++ b/spec/parse_html_spec.rb
@@ -1,0 +1,10 @@
+require 'helper'
+require 'faraday_middleware/response/parse_html'
+
+describe FaradayMiddleware::ParseHtml, :type => :response do
+  it "does not choke on invalid xml" do
+    ['{!', '"a"', 'true', 'null', '1'].each do |data|
+      expect { process(data) }.to_not raise_error(Faraday::Error::ParsingError)
+    end
+  end
+end


### PR DESCRIPTION
Now that faraday-stack has been deprecated in favour of faraday_middleware I found the only thing I was missing was the HTML parsing middleware.

The reason I feel this is needed alongside the existing XML parser is because Nokogiri's HTML parser is much more lenient of errors in the markup which I come across very often when pulling in HTML.

Thanks!
