### PR TITLE
Minor updates to redirects

### DIFF
--- a/spec/follow_redirects_spec.rb
+++ b/spec/follow_redirects_spec.rb
@@ -5,6 +5,8 @@ require 'forwardable'
 
 describe FaradayMiddleware::FollowRedirects do
   let(:connection) {
+
+    redirect_body = '<html><head><title>Site</title></head><body><a href="/found">moved here</a></body></html>'
     Faraday.new do |c|
       c.use described_class
       c.adapter :test do |stub|
@@ -13,6 +15,8 @@ describe FaradayMiddleware::FollowRedirects do
         stub.get('/found')   { [200, {'Content-Type' => 'text/plain'}, 'fin'] }
         stub.get('/loop')    { [302, {'Location' => '/loop'}, ''] }
         stub.get('/temp')    { [307, {'Location' => '/found'}, ''] }
+        stub.get('/no-location') {[301, {'Content-Type' => 'text/html'}, redirect_body]}
+        stub.get('/no-location-or-body') {[301, {'Content-Type' => 'text/html'}, '']}
       end
     end
   }
@@ -28,11 +32,19 @@ describe FaradayMiddleware::FollowRedirects do
     get('/temp').body.should eql('fin')
   end
 
+  it "uses the the link in the body for redirection" do 
+    get('/no-location').body.should eql('fin')
+  end
+
   it "follows redirect twice" do
     post('/create').body.should eql('fin')
   end
 
   it "raises exception on loop" do
     expect { get('/loop') }.to raise_error(FaradayMiddleware::RedirectLimitReached)
+  end
+
+  it "raises exception when there is no place to redirect to" do
+    expect { get('/no-location-or-body') }.to raise_error(FaradayMiddleware::NoRedirectLocation)
   end
 end


### PR DESCRIPTION
I had recently published a simple gem Unwind to handle redirects: https://github.com/scottwater/unwind

Then someone pointed me to FollowRedirects middleware which does 99% of the job. 

This pull request adds:
- Support for 307 redirects. Not sure why this was just a todo comment previously. 
- Handles edge cases where there is no location header and the link is just in the body of the response. 
- Raises a specific exception where no location (or html) are available but a redirect status code is issued.
- allows me to kill my own gem. :)
