### PR TITLE
Add Header Middlware

### DIFF
--- a/lib/faraday_middleware.rb
+++ b/lib/faraday_middleware.rb
@@ -4,6 +4,7 @@ module FaradayMiddleware
   autoload :OAuth,           'faraday_middleware/request/oauth'
   autoload :OAuth2,          'faraday_middleware/request/oauth2'
   autoload :EncodeJson,      'faraday_middleware/request/encode_json'
+  autoload :AddHeader,       'faraday_middleware/request/add_header'
   autoload :Mashify,         'faraday_middleware/response/mashify'
   autoload :Rashify,         'faraday_middleware/response/rashify'
   autoload :ParseJson,       'faraday_middleware/response/parse_json'
@@ -17,9 +18,10 @@ module FaradayMiddleware
 
   if Faraday.respond_to? :register_middleware
     Faraday.register_middleware :request,
-      :oauth    => lambda { OAuth },
-      :oauth2   => lambda { OAuth2 },
-      :json     => lambda { EncodeJson }
+      :oauth          => lambda { OAuth },
+      :oauth2         => lambda { OAuth2 },
+      :json           => lambda { EncodeJson },
+      :add_header     => lambda { AddHeader}
 
     Faraday.register_middleware :response,
       :mashify  => lambda { Mashify },

--- a/lib/faraday_middleware/request/add_header.rb
+++ b/lib/faraday_middleware/request/add_header.rb
@@ -1,0 +1,22 @@
+require 'faraday'
+
+module FaradayMiddleware
+  # Request middleware that adds a sipmle header. Useful for
+  # when you have headers that should be sent with every
+  # request. Example, API's that use headers to send API keys.
+
+  class AddHeader < Faraday::Middleware
+    attr_reader :name, :value
+
+    def initialize(app, name, value)
+      super app
+      @name, @value = name, value
+    end
+
+    def call(env)
+      env[:request_headers][name] = value
+
+      @app.call env
+    end
+  end
+end

--- a/spec/add_header_spec.rb
+++ b/spec/add_header_spec.rb
@@ -1,0 +1,20 @@
+require 'helper'
+require 'faraday_middleware/request/add_header'
+
+describe FaradayMiddleware::AddHeader do
+  let(:subject) { described_class }
+
+  def make_app(*args)
+    described_class.new lambda{|env| env}, *args
+  end
+
+  it "should add the specified header with the value" do
+    env = { :request_headers => Faraday::Utils::Headers.new }
+
+    app = make_app 'X-Restful-API-Key', 'foo'
+
+    app.call env
+
+    env[:request_headers]['X-Restful-API-Key'].should == 'foo'
+  end
+end


### PR DESCRIPTION
I've added a simple middleware that adds an arbitrary header to every request. Useful when you use Faraday with API's that use headers for auth.
