### PR TITLE
Allow custom mash classes at the instance level.

### DIFF
--- a/lib/faraday_middleware/response/mashify.rb
+++ b/lib/faraday_middleware/response/mashify.rb
@@ -4,6 +4,8 @@ module FaradayMiddleware
   # Public: Converts parsed response bodies to a Hashie::Mash if they were of
   # Hash or Array type.
   class Mashify < Faraday::Response::Middleware
+    attr_accessor :mash_class
+
     class << self
       attr_accessor :mash_class
     end
@@ -13,12 +15,17 @@ module FaradayMiddleware
       self.mash_class = ::Hashie::Mash
     end
 
+    def initialize(app = nil, options = {})
+      super(app)
+      self.mash_class = options[:mash_class] || self.class.mash_class
+    end
+
     def parse(body)
       case body
       when Hash
-        self.class.mash_class.new(body)
+        mash_class.new(body)
       when Array
-        body.map { |item| item.is_a?(Hash) ? self.class.mash_class.new(item) : item }
+        body.map { |item| item.is_a?(Hash) ? mash_class.new(item) : item }
       else
         body
       end

--- a/spec/mashify_spec.rb
+++ b/spec/mashify_spec.rb
@@ -47,9 +47,19 @@ describe FaradayMiddleware::Mashify do
       values[1].username.should == 'sferik'
     end
 
-    it 'should allow for use of custom Mash subclasses' do
+    it 'should allow for use of custom Mash subclasses at the class level' do
       class MyMash < ::Hashie::Mash; end
       described_class.mash_class = MyMash
+
+      env = { :body => { "name" => "Erik Michaels-Ober", "username" => "sferik" } }
+      me  = mashify.on_complete(env)
+
+      me.class.should == MyMash
+    end
+
+    it 'should allow for use of custom Mash subclasses at the instancel evel' do
+      class MyMash < ::Hashie::Mash; end
+      mashify = described_class.new(nil, mash_class: MyMash)
 
       env = { :body => { "name" => "Erik Michaels-Ober", "username" => "sferik" } }
       me  = mashify.on_complete(env)


### PR DESCRIPTION
When overriding the class used by the `Mashify` and `Rashify` middlewares, it seems like a bad idea to implement this customization as a class attribute, since any apps using multiple Faraday-based Gems would all be subject to the same custom `Mash` class.

This pull request is an attempt to move in the direction of instance-level custom `Mash` classes without breaking the current API.
