### PR TITLE
Only require 'json' if it's undefined.

### DIFF
--- a/lib/faraday_middleware/response/parse_json.rb
+++ b/lib/faraday_middleware/response/parse_json.rb
@@ -3,7 +3,9 @@ require 'faraday_middleware/response_middleware'
 module FaradayMiddleware
   # Public: Parse response bodies as JSON.
   class ParseJson < ResponseMiddleware
-    dependency 'json'
+    dependency {
+      require 'json' unless defined?(JSON)
+    }
 
     define_parser { |body|
       JSON.parse body unless body.empty?


### PR DESCRIPTION
In light of the recent MultiJSON removal and @mislav's comments on #30, this patch allows JSON Gems with a compatibility API to be used without the dependency defined on `FaradayMiddleware::ParseJson` overriding it when it's loaded.

This is purely a load order issue. If the following is run before `FaradayMiddleware::ParseJson` is loaded:

```
require 'yajl/json_gem'
```

this call to `Faraday::Middleware.dependency` in `FaradayMiddleware::ParseJson`:

```
dependency 'json'
```

would effectively cause a:

```
require 'json'
```

which would wipe out Yajl's JSON gem compatibility and replacing it with the actual JSON gem or stdlib library.
