### PR TITLE
Don't pass headers to rack with nil or non-string values.

### DIFF
--- a/lib/faraday_middleware/rack_compatible.rb
+++ b/lib/faraday_middleware/rack_compatible.rb
@@ -54,7 +54,7 @@ module FaradayMiddleware
       headers.clear
 
       env.each do |name, value|
-        next unless String === name
+        next unless String === name && String === value
         if NonPrefixedHeaders.include? name or name.index('HTTP_') == 0
           name = name.sub(/^HTTP_/, '').downcase.tr('_', '-')
           headers[name] = value


### PR DESCRIPTION
Was getting some issues with net-http and rack-cache stemming from passing HTTP_IF_MODIFIED_SINCE and HTTP_IF_NONE_MATCH headers with nil values.
