### PR TITLE
Mashify handling nested arrays of hashes properly

### DIFF
--- a/lib/faraday_middleware/response/mashify.rb
+++ b/lib/faraday_middleware/response/mashify.rb
@@ -25,7 +25,7 @@ module FaradayMiddleware
       when Hash
         mash_class.new(body)
       when Array
-        body.map { |item| item.is_a?(Hash) ? mash_class.new(item) : item }
+        body.map { |item| parse(item) }
       else
         body
       end

--- a/spec/mashify_spec.rb
+++ b/spec/mashify_spec.rb
@@ -39,6 +39,13 @@ describe FaradayMiddleware::Mashify do
       us.last.username.should == 'pengwynn'
     end
 
+    it 'should handle nested arrays of hashes' do
+      env = { :body => [[{ "username" => "sferik" }, { "username" => "pengwynn" }]] }
+      us  = mashify.on_complete(env)
+      us.first.first.username.should == 'sferik'
+      us.first.last.username.should == 'pengwynn'
+    end
+
     it 'should handle mixed arrays' do
       env = { :body => [123, { "username" => "sferik" }, 456] }
       values = mashify.on_complete(env)


### PR DESCRIPTION
I changed `FaradayMiddleware::Mashify#parse` so it runs recursively after encountering an `Array`. So with the following connection:

``` ruby
connection = Faraday.new do |builder|
  builder.response :mashify
  builder.response :json

  builder.adapter :test do |stub|
    stub.get('/url') do
      data = [[{a: 1, b: 2}]]
      [200, {}, data.to_json]
    end
  end
end
```

we get a `Hashie::Mash` inside, not a `Hash`.

``` ruby
connection.get('/url').body
# => [[#<Hashie::Mash a=1 b=2>]]
```
