### PR TITLE
Using multi_json when it's available

### DIFF
--- a/lib/faraday_middleware/request/encode_json.rb
+++ b/lib/faraday_middleware/request/encode_json.rb
@@ -13,7 +13,11 @@ module FaradayMiddleware
     MIME_TYPE    = 'application/json'.freeze
 
     dependency do
-      require 'json' unless defined?(::JSON)
+      begin
+        require 'multi_json' unless defined?(::MultiJson)
+      rescue LoadError
+        require 'json' unless defined?(::JSON)
+      end
     end
 
     def call(env)
@@ -24,7 +28,15 @@ module FaradayMiddleware
     end
 
     def encode(data)
-      ::JSON.dump data
+      if defined? ::MultiJson
+        if ::MultiJson.respond_to? :dump
+          ::MultiJson.dump data
+        else
+          ::MultiJson.encode data
+        end
+      else
+        ::JSON.dump data
+      end
     end
 
     def match_content_type(env)

--- a/lib/faraday_middleware/response/parse_json.rb
+++ b/lib/faraday_middleware/response/parse_json.rb
@@ -3,12 +3,27 @@ require 'faraday_middleware/response_middleware'
 module FaradayMiddleware
   # Public: Parse response bodies as JSON.
   class ParseJson < ResponseMiddleware
+
     dependency do
-      require 'json' unless defined?(::JSON)
+      begin
+        require 'multi_json' unless defined?(::MultiJson)
+      rescue LoadError
+        require 'json' unless defined?(::JSON)
+      end
     end
 
     define_parser do |body|
-      ::JSON.parse body unless body.strip.empty?
+      unless body.strip.empty?
+        if defined? ::MultiJson
+          if ::MultiJson.respond_to? :load
+            ::MultiJson.load body
+          else
+            ::MultiJson.decode body
+          end
+        else
+          ::JSON.load body
+        end
+      end
     end
 
     # Public: Override the content-type of the response with "application/json"


### PR DESCRIPTION
I just added multi_json as dependency in case of someone wants to use another json engine.

If multi_json is not available, it continues using json library as before.

I've tested it with multi_json gems 1.2.0 and 1.3.6 (there's a new API in the latest),
and without multi_json installed. 
