### PR TITLE
Fix SyntaxError on middleware registration

### DIFF
--- a/lib/faraday_middleware.rb
+++ b/lib/faraday_middleware.rb
@@ -18,14 +18,14 @@ module FaradayMiddleware
   autoload :FollowRedirects, 'faraday_middleware/response/follow_redirects'
   autoload :Instrumentation, 'faraday_middleware/instrumentation'
 
-  Faraday::Request.register_middleware {
+  Faraday::Request.register_middleware({
     :oauth    => OAuth,
     :oauth2   => OAuth2,
     :json     => EncodeJson,
     :method_override => MethodOverride
-  }
+  })
 
-  Faraday::Response.register_middleware {
+  Faraday::Response.register_middleware({
     :mashify  => Mashify,
     :rashify  => Rashify,
     :json     => ParseJson,
@@ -37,10 +37,10 @@ module FaradayMiddleware
     :caching  => Caching,
     :follow_redirects => FollowRedirects,
     :chunked  => Chunked
-  }
+  })
 
-  Faraday::Middleware.register_middleware {
+  Faraday::Middleware.register_middleware({
     :instrumentation => Instrumentation
-  }
+  })
 end
 require 'faraday_middleware/backwards_compatibility'


### PR DESCRIPTION
We picked this up with the faraday-http-cache test suite, since the tests in this project the `faraday_middleware` file isn't loaded by any of the existing tests - let me know I should add a require for it on the `helper` file.

In related news, there is some loading issues related to `Faraday::Env` and other dependencies that is breaking the existing tests. I might check on that later :smile: 
