### PR TITLE
do not convert into get request if user does not want it

### DIFF
--- a/lib/faraday_middleware/response/follow_redirects.rb
+++ b/lib/faraday_middleware/response/follow_redirects.rb
@@ -68,9 +68,8 @@ module FaradayMiddleware
     private
 
     def transform_into_get?(response)
+      return false if @options[:no_method_change]
       return false if [:head, :options].include? response.env[:method]
-      # Never convert head or options to a get. That would just be silly.
-
       !@replay_request_codes.include? response.status
     end
 

--- a/spec/follow_redirects_spec.rb
+++ b/spec/follow_redirects_spec.rb
@@ -137,7 +137,6 @@ describe FaradayMiddleware::FollowRedirects do
   end
 
   context "when cookies option" do
-
     let(:cookies) { 'cookie1=abcdefg; cookie2=1234567; cookie3=awesome' }
 
     context "is :all" do
@@ -191,6 +190,14 @@ describe FaradayMiddleware::FollowRedirects do
 
   context "for an HTTP 307 response" do
     it_behaves_like 'a successful redirection', 307
+    it_behaves_like 'a replayed redirection', 307
+  end
+
+  context "with no_method_change option" do
+    let(:middleware_options) { { :no_method_change => true } }
+    it_behaves_like 'a replayed redirection', 301
+    it_behaves_like 'a replayed redirection', 302
+    it_behaves_like 'a replayed redirection', 303
     it_behaves_like 'a replayed redirection', 307
   end
 


### PR DESCRIPTION
@sferic
We had a bunch of customers give us 301/302 redirects and expect the post/put train to continue, so we would like to disable this method transformation to avoid future support requests. Not sure about the naming, maybe you have a better idea...
