### PR TITLE
Use Bearer authorization header

### DIFF
--- a/lib/faraday_middleware/request/oauth2.rb
+++ b/lib/faraday_middleware/request/oauth2.rb
@@ -34,7 +34,7 @@ module FaradayMiddleware
 
       if token = params[param_name] and !token.empty?
         env[:url].query = build_query params
-        env[:request_headers][AUTH_HEADER] ||= %(Token token="#{token}")
+        env[:request_headers][AUTH_HEADER] ||= %(Bearer #{token})
       end
 
       @app.call env

--- a/spec/oauth2_spec.rb
+++ b/spec/oauth2_spec.rb
@@ -41,7 +41,7 @@ describe FaradayMiddleware::OAuth2 do
     it "creates header for explicit token" do
       request = perform(:q => 'hello', :access_token => 'abc123')
       expect(query_params(request)).to eq('q' => 'hello', 'access_token' => 'abc123')
-      expect(auth_header(request)).to eq(%(Token token="abc123"))
+      expect(auth_header(request)).to eq(%(Bearer abc123))
     end
   end
 
@@ -53,13 +53,13 @@ describe FaradayMiddleware::OAuth2 do
     end
 
     it "adds token header" do
-      expect(auth_header(perform)).to eq(%(Token token="XYZ"))
+      expect(auth_header(perform)).to eq(%(Bearer XYZ))
     end
 
     it "overrides default with explicit token" do
       request = perform(:q => 'hello', :access_token => 'abc123')
       expect(query_params(request)).to eq('q' => 'hello', 'access_token' => 'abc123')
-      expect(auth_header(request)).to eq(%(Token token="abc123"))
+      expect(auth_header(request)).to eq(%(Bearer abc123))
     end
 
     it "clears default with empty explicit token" do
@@ -92,7 +92,7 @@ describe FaradayMiddleware::OAuth2 do
     it "overrides default with explicit token" do
       request = perform(:oauth => 'abc123')
       expect(query_params(request)).to eq('oauth' => 'abc123')
-      expect(auth_header(request)).to eq(%(Token token="abc123"))
+      expect(auth_header(request)).to eq(%(Bearer abc123))
     end
   end
 


### PR DESCRIPTION
Authorization: Token token="..." has been removed from OAuth 2.0 draft
in v10, and later drafts and RFC version uses Bearer token header.