### PR TITLE
parse_dates middleware takes optional milliseconds into consideration

### DIFF
--- a/lib/faraday_middleware/response/parse_dates.rb
+++ b/lib/faraday_middleware/response/parse_dates.rb
@@ -4,7 +4,7 @@ require "faraday"
 module FaradayMiddleware
   # Parse dates from response body
   class ParseDates < ::Faraday::Response::Middleware
-    ISO_DATE_FORMAT = /\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\Z/m
+    ISO_DATE_FORMAT = /\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z\Z/m
 
     def initialize(app, options = {})
       @regexp = options[:match] || ISO_DATE_FORMAT

--- a/spec/parse_dates_spec.rb
+++ b/spec/parse_dates_spec.rb
@@ -15,6 +15,10 @@ describe FaradayMiddleware::ParseDates, :type => :response do
     expect(process({"x" => "2012-02-01T13:14:15Z"}).body["x"].to_s).to eq(parsed)
   end
 
+  it "parses dates with milliseconds" do
+    expect(process({"x" => "2012-02-01T13:14:15.123Z"}).body["x"]).to eq(Time.parse("2012-02-01T13:14:15.123Z"))
+  end
+
   it "parses nested dates in hash" do
     expect(process({"x" => {"y" => "2012-02-01T13:14:15Z"}}).body["x"]["y"].to_s).to eq(parsed)
   end


### PR DESCRIPTION
taking optional milliseconds into consideration
