### PR TITLE
Update faraday_middleware.gemspec

### DIFF
--- a/faraday_middleware.gemspec
+++ b/faraday_middleware.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'faraday_middleware/version'
 
 Gem::Specification.new do |spec|
-  spec.add_dependency 'faraday', ['>= 0.7.4', '< 0.9']
+  spec.add_dependency 'faraday', '>= 0.7.4'
   spec.add_development_dependency 'bundler', '~> 1.0'
   spec.authors = ["Erik Michaels-Ober", "Wynn Netherland"]
   spec.description = %q{Various middleware for Faraday}


### PR DESCRIPTION
The newest faraday version is not "0.9", it should allow newer version.
