### PR TITLE
Option to clear auth header on redirects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ pkg
 
 # Rubinius
 *.rbc
+
+# RubyMine
+.idea

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source 'https://rubygems.org'
 
-gem 'jruby-openssl', :platforms => :jruby
-gem 'json', :platforms => [:jruby, :ruby_18]
-gem 'multi_xml', '>= 0.5.3'
 gem 'hashie', '>= 1.2'
+gem 'jruby-openssl', :platforms => :jruby
+gem 'json', :platforms => [:jruby, :rbx, :ruby_18]
+gem 'multi_xml', '>= 0.5.3'
 gem 'rack-cache', '>= 1.1'
 gem 'rake', '>= 0.9'
 gem 'rash', '>= 0.3'
@@ -16,9 +16,8 @@ group :test do
 end
 
 platforms :rbx do
-  gem 'rubysl-base64', '~> 2.0'
-  gem 'rubysl-json', '~> 2.0'
-  gem 'rubysl-singleton', '~> 2.0'
+  gem 'rubinius-coverage', '~> 2.0'
+  gem 'rubysl', '~> 2.0'
 end
 
 gemspec

--- a/lib/faraday_middleware/response/follow_redirects.rb
+++ b/lib/faraday_middleware/response/follow_redirects.rb
@@ -32,17 +32,22 @@ module FaradayMiddleware
     # Default value for max redirects followed
     FOLLOW_LIMIT = 3
 
+    AUTH_HEADER = 'Authorization'.freeze
+
     # Public: Initialize the middleware.
     #
     # options - An options Hash (default: {}):
-    #           :limit               - A Numeric redirect limit (default: 3)
-    #           :standards_compliant - A Boolean indicating whether to respect
+    #     :limit                      - A Numeric redirect limit (default: 3)
+    #     :standards_compliant        - A Boolean indicating whether to respect
     #                                  the HTTP spec when following 301/302
     #                                  (default: false)
-    #           :cookies             - An Array of Strings (e.g.
+    #     :cookies                    - An Array of Strings (e.g.
     #                                  ['cookie1', 'cookie2']) to choose
     #                                  cookies to be kept, or :all to keep
     #                                  all cookies (default: []).
+    #     :clear_authorization_header - A Boolean indicating whether the request
+    #                                 Authorization header should be cleared on
+    #                                 redirects (default: false)
     def initialize(app, options = {})
       super(app)
       @options = options
@@ -90,6 +95,8 @@ module FaradayMiddleware
         env[:body] = request_body
       end
 
+      env[:request_headers].delete(AUTH_HEADER) if clear_authorization_header?
+
       ENV_TO_CLEAR.each {|key| env.delete key }
 
       env
@@ -125,6 +132,10 @@ module FaradayMiddleware
 
     def standards_compliant?
       @options.fetch(:standards_compliant, false)
+    end
+
+    def clear_authorization_header?
+      @options.fetch(:clear_authorization_header, false)
     end
   end
 end

--- a/spec/follow_redirects_spec.rb
+++ b/spec/follow_redirects_spec.rb
@@ -166,7 +166,7 @@ describe FaradayMiddleware::FollowRedirects do
     end
   end
 
-  context "when clear_authorization_header option is enabled" do
+  context "when clear_authorization_header option" do
     context "is false" do
       it "redirects with the original authorization headers" do
         conn = connection(:clear_authorization_header => false) do |stub|
@@ -188,7 +188,7 @@ describe FaradayMiddleware::FollowRedirects do
 
     context "is true" do
       it "redirects without original authorization headers" do
-        conn = connection(:clear_authorization_header => false) do |stub|
+        conn = connection(:clear_authorization_header => true) do |stub|
           stub.get('/redirect') {
             [301, {'Location' => '/found'}, '']
           }

--- a/spec/follow_redirects_spec.rb
+++ b/spec/follow_redirects_spec.rb
@@ -166,6 +166,46 @@ describe FaradayMiddleware::FollowRedirects do
     end
   end
 
+  context "when clear_authorization_header option is enabled" do
+    context "is false" do
+      it "redirects with the original authorization headers" do
+        conn = connection(:clear_authorization_header => false) do |stub|
+          stub.get('/redirect') {
+            [301, {'Location' => '/found'}, '']
+          }
+          stub.get('/found') { |env|
+            [200, {'Content-Type' => 'text/plain'}, env[:request_headers]['Authorization']]
+          }
+        end
+
+        response = conn.get('/redirect') { |req|
+          req.headers['Authorization'] = 'success'
+        }
+
+        expect(response.body).to eq('success')
+      end
+    end
+
+    context "is true" do
+      it "redirects without original authorization headers" do
+        conn = connection(:clear_authorization_header => false) do |stub|
+          stub.get('/redirect') {
+            [301, {'Location' => '/found'}, '']
+          }
+          stub.get('/found') { |env|
+            [200, {'Content-Type' => 'text/plain'}, env[:request_headers]['Authorization']]
+          }
+        end
+
+        response = conn.get('/redirect') { |req|
+          req.headers['Authorization'] = 'failed'
+        }
+
+        expect(response.body).to be_nil
+      end
+    end
+  end
+
   [301, 302].each do |code|
     context "for an HTTP #{code} response" do
       it_behaves_like 'a successful redirection', code


### PR DESCRIPTION
Added an option that will allow the FollowRedirects middleware to clear authorization headers on redirects. The HTTP spec doesn't seem to specify whether particular headers should be omitted/included in redirects (http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3) so it seems reasonable for an option like this to be built into the middleware