### PR TITLE
fix cookie handling when following redirects

### DIFF
--- a/lib/faraday_middleware/response/follow_redirects.rb
+++ b/lib/faraday_middleware/response/follow_redirects.rb
@@ -80,7 +80,7 @@ module FaradayMiddleware
       env[:url] += response['location']
       if @options[:cookies]
         cookies = keep_cookies(env)
-        env[:request_headers][:cookies] = cookies unless cookies.nil?
+        env[:request_headers]["Cookie"] = cookies unless cookies.nil?
       end
 
       if convert_to_get?(response)
@@ -106,7 +106,7 @@ module FaradayMiddleware
 
     def keep_cookies(env)
       cookies = @options.fetch(:cookies, [])
-      response_cookies = env[:response_headers][:cookies]
+      response_cookies = env[:response_headers]["set-cookie"]
       cookies == :all ? response_cookies : selected_request_cookies(response_cookies)
     end
 

--- a/spec/follow_redirects_spec.rb
+++ b/spec/follow_redirects_spec.rb
@@ -143,9 +143,9 @@ describe FaradayMiddleware::FollowRedirects do
     context "is :all" do
       it "puts all cookies from the response into the next request" do
         expect(connection(:cookies => :all) do |stub|
-          stub.get('/')           { [301, {'Location' => '/found', 'Cookies' => cookies }, ''] }
+          stub.get('/')           { [301, {'Location' => '/found', 'Set-Cookie' => cookies }, ''] }
           stub.get('/found')      { [200, {'Content-Type' => 'text/plain'}, ''] }
-        end.get('/').env[:request_headers][:cookies]).to eq(cookies)
+        end.get('/').env[:request_headers]['Cookie']).to eq(cookies)
       end
 
       it "not set cookies header on request when response has no cookies" do
@@ -159,9 +159,9 @@ describe FaradayMiddleware::FollowRedirects do
     context "is an array of cookie names" do
       it "puts selected cookies from the response into the next request" do
         expect(connection(:cookies => ['cookie2']) do |stub|
-          stub.get('/')           { [301, {'Location' => '/found', 'Cookies' => cookies }, ''] }
+          stub.get('/')           { [301, {'Location' => '/found', 'Set-Cookie' => cookies }, ''] }
           stub.get('/found')      { [200, {'Content-Type' => 'text/plain'}, ''] }
-        end.get('/').env[:request_headers][:cookies]).to eq('cookie2=1234567')
+        end.get('/').env[:request_headers]['Cookie']).to eq('cookie2=1234567')
       end
     end
   end


### PR DESCRIPTION
previous implementation was using the wrong key names for both the request and response namespaces.

I was surprised to find this bug because I guess it means no one was using this feature? Or perhaps this worked with a previous version of of Faraday which did some sort of conversion/normalization of the namespace further down the line? (looks like @mrmicahcooper, @mislav, and @evilmarty have made commits related to cookies — any insight into this?)

I only updated the existing tests. So, there's nothing stopping this new implementation from being wrong as well, other than that I tested it manually with urls that require redirects and cookies. This is theoretically fine because the namespace corresponds with the HTTP spec, which the previous version did not.

Let me know what you think.
