### PR TITLE
support the .NET DateTime Wire Format

### DIFF
--- a/lib/faraday_middleware/response/parse_dates.rb
+++ b/lib/faraday_middleware/response/parse_dates.rb
@@ -5,6 +5,7 @@ module FaradayMiddleware
   # Parse dates from response body
   class ParseDates < ::Faraday::Response::Middleware
     ISO_DATE_FORMAT = /\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z\Z/m
+    MS_DATE_FORMAT = /\/Date\((\d+)\)\//
 
     def initialize(app, options = {})
       @regexp = options[:match] || ISO_DATE_FORMAT
@@ -31,6 +32,8 @@ module FaradayMiddleware
         end
       when @regexp
         Time.parse(value)
+      when MS_DATE_FORMAT
+        Time.at(value.match(MS_DATE_FORMAT)[1].to_i/1000).utc
       else
         value
       end

--- a/spec/parse_dates_spec.rb
+++ b/spec/parse_dates_spec.rb
@@ -45,6 +45,6 @@ describe FaradayMiddleware::ParseDates, :type => :response do
   it "parses dates in the .NET DateTime Wire Format" do
     # http://msdn.microsoft.com/en-us/library/bb412170(v=vs.110).aspx
     # Scroll down to 'DateTime Wire Format'
-    expect(process({"x" => "/Date(1409326098000)/"}).body["x"].to_s).to eq "2014-08-29 15:28:18 UTC"
+    expect(process({"x" => "/Date(1328102055000)/"}).body["x"].to_s).to eq(parsed)
   end
 end

--- a/spec/parse_dates_spec.rb
+++ b/spec/parse_dates_spec.rb
@@ -41,4 +41,10 @@ describe FaradayMiddleware::ParseDates, :type => :response do
     expect(process({"x" => "12012-02-01T13:14:15Z"}).body["x"].to_s).to eq "12012-02-01T13:14:15Z"
     expect(process({"x" => "2012-02-01T13:14:15Z\nfoo"}).body["x"].to_s).to eq "2012-02-01T13:14:15Z\nfoo"
   end
+
+  it "parses dates in the .NET DateTime Wire Format" do
+    # http://msdn.microsoft.com/en-us/library/bb412170(v=vs.110).aspx
+    # Scroll down to 'DateTime Wire Format'
+    expect(process({"x" => "/Date(1409326098000)/"}).body["x"].to_s).to eq "2014-08-29 15:28:18 UTC"
+  end
 end


### PR DESCRIPTION
Hi,
I've had the pleasure of dealing with some serialized .NET objects and notice the dates being presented as /Date(123123123123)/  Thought it might be useful to have the faraday middleware convert those into proper Time objects for ease of use.  I ignored the optional implementation with timezones as the two api's I've been dealing with lately didn't use them.