### PR TITLE
Middleware to limit request size

### DIFF
--- a/lib/faraday_middleware.rb
+++ b/lib/faraday_middleware.rb
@@ -24,7 +24,8 @@ module FaradayMiddleware
       :oauth    => lambda { OAuth },
       :oauth2   => lambda { OAuth2 },
       :json     => lambda { EncodeJson },
-      :method_override => lambda { MethodOverride }
+      :method_override => lambda { MethodOverride },
+      :limit_size => lambda { LimitSize },
 
     Faraday::Response.register_middleware \
       :mashify  => lambda { Mashify },

--- a/lib/faraday_middleware/request/limit_size.rb
+++ b/lib/faraday_middleware/request/limit_size.rb
@@ -37,7 +37,7 @@ module FaradayMiddleware
       options.fetch(:max_query_length, 1024 * 10)
     end
 
-    QueryTooLong = Class.new(Faraday::Error)
+    QueryTooLong = Class.new(StandardError)
   end
 
 end

--- a/lib/faraday_middleware/request/limit_size.rb
+++ b/lib/faraday_middleware/request/limit_size.rb
@@ -1,0 +1,43 @@
+require "faraday"
+
+module FaradayMiddleware
+  # Request middleware that limits the size of the request.
+  #
+  # Web servers can only accept requests of finite size. This middleware will
+  # cause requests that are too large to fail at the client side, with an
+  # explanatory error, instead of hitting the server with the giant request.
+  #
+  # Currently, it only checks the length of the query string.
+  #
+  # Size limit is configurable. Eg:
+  # Faraday.new do |conn|
+  #   conn.request :limit_size, :max_query_length => 8_000
+  #   conn.adapter Faraday.default_adapter
+  # end
+  #
+  class LimitSize < Faraday::Middleware
+    attr_accessor :options
+
+    def initialize(app = nil, options = {})
+      super(app)
+      self.options = options
+    end
+
+    def call(env)
+      if env.url.query.to_s.length > max_query_length
+        fail QueryTooLong, "length is #{env.url.query.length}, max is #{max_query_length}"
+      end
+      @app.call(env)
+    end
+
+    private
+
+    def max_query_length
+      # See https://github.com/macournoyer/thin/blob/v1.6.3/ext/thin_parser/thin.c#L71
+      options.fetch(:max_query_length, 1024 * 10)
+    end
+
+    QueryTooLong = Class.new(StandardError)
+  end
+
+end

--- a/lib/faraday_middleware/request/limit_size.rb
+++ b/lib/faraday_middleware/request/limit_size.rb
@@ -37,7 +37,7 @@ module FaradayMiddleware
       options.fetch(:max_query_length, 1024 * 10)
     end
 
-    QueryTooLong = Class.new(StandardError)
+    QueryTooLong = Class.new(Faraday::Error)
   end
 
 end

--- a/spec/unit/limit_size_spec.rb
+++ b/spec/unit/limit_size_spec.rb
@@ -1,0 +1,35 @@
+require "helper"
+require "faraday_middleware/request/limit_size"
+
+describe FaradayMiddleware::LimitSize, :type => :request do
+
+  let(:env) { double(:env, :url => url) }
+  let(:url) { double(:url, :query => query) }
+
+  describe "limiting query length" do
+
+    let(:middleware) { described_class.new(proc {}, :max_query_length => 5) }
+
+    context "when the query is not too long" do
+
+      let(:query) { "id=1" }
+
+      it "does not raise an error" do
+        expect { middleware.call(env) }.not_to raise_error
+      end
+
+    end
+
+    context "when the query is too long" do
+
+      let(:query) { "id=1&other=fooooooooooooooooooo" }
+
+      it "raises an error" do
+        expect { middleware.call(env) }.to raise_error(FaradayMiddleware::LimitSize::QueryTooLong)
+      end
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
While doing some internal API requests, we had an error because the request was beyond the limits of the Thin server. 

That error was difficult to find. This middleware makes it easy to prevent.