### PR TITLE
Refer to ActiveSupport::Notifications as a top-level constant

### DIFF
--- a/lib/faraday_middleware/instrumentation.rb
+++ b/lib/faraday_middleware/instrumentation.rb
@@ -22,7 +22,7 @@ module FaradayMiddleware
     end
 
     def call(env)
-      ActiveSupport::Notifications.instrument(@name, env) do
+      ::ActiveSupport::Notifications.instrument(@name, env) do
         @app.call(env)
       end
     end


### PR DESCRIPTION
After upgrading faraday to 0.9.0 and faraday_middleware to 0.9.1, I started having an issue with a gem that relies on both, [geoip2](https://github.com/YotpoLtd/geoip2), being unable to find `ActiveSupport::Notifications`:

```
NameError: uninitialized constant FaradayMiddleware::ActiveSupport::Notifications
/gems/faraday_middleware-0.9.1/lib/faraday_middleware/instrumentation.rb:25 in "call"
/gems/faraday_middleware-0.9.1/lib/faraday_middleware/response_middleware.rb:30 in "call"
/gems/faraday_middleware-0.9.1/lib/faraday_middleware/request/encode_json.rb:23 in "call"
/gems/faraday-0.9.0/lib/faraday/response.rb:8 in "call"
/gems/faraday-0.9.0/lib/faraday/request/authorization.rb:38 in "call"
/gems/faraday-0.9.0/lib/faraday/rack_builder.rb:139 in "build_response"
/gems/faraday-0.9.0/lib/faraday/connection.rb:377 in "run_request"
/gems/faraday-0.9.0/lib/faraday/connection.rb:140 in "get"
/bundler/gems/geoip2-cf95b67c88fc/lib/geoip2/client.rb:41 in "block in get"
/bundler/gems/geoip2-cf95b67c88fc/lib/geoip2/client.rb:69 in "call"
/bundler/gems/geoip2-cf95b67c88fc/lib/geoip2/client.rb:69 in "block in preform"
/gems/activesupport-3.2.21/lib/active_support/notifications.rb:125 in "instrument"
/bundler/gems/geoip2-cf95b67c88fc/lib/geoip2/client.rb:68 in "preform"
/bundler/gems/geoip2-cf95b67c88fc/lib/geoip2/client.rb:40 in "get"
/bundler/gems/geoip2-cf95b67c88fc/lib/geoip2/api/city.rb:5 in "city"
/bundler/gems/geoip2-cf95b67c88fc/lib/geoip2.rb:70 in "method_missing"
```

Changing the `Instrumentation` class to refer to it as an explicit top-level constant seems to resolve it.