### PR TITLE
Instrument asynchronous requests as well

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ group :test do
   gem 'rspec', '>= 3'
   gem 'simplecov'
   gem 'webmock'
+  gem 'activesupport', '~> 4.2.0', :platforms => [:mri_19, :mri_20, :mri_21]
 end
 
 gemspec

--- a/lib/faraday_middleware/instrumentation.rb
+++ b/lib/faraday_middleware/instrumentation.rb
@@ -22,9 +22,17 @@ module FaradayMiddleware
     end
 
     def call(env)
-      ::ActiveSupport::Notifications.instrument(@name, env) do
-        @app.call(env)
-      end
+      instrumenter.start(@name, env)
+
+      response = @app.call(env)
+      response.on_complete {|env| instrumenter.finish(@name, env) }
+      response
+    end
+
+    private
+
+    def instrumenter
+      ::ActiveSupport::Notifications.instrumenter
     end
   end
 end

--- a/spec/unit/instrumentation_spec.rb
+++ b/spec/unit/instrumentation_spec.rb
@@ -1,0 +1,35 @@
+require 'helper'
+require 'faraday_middleware/instrumentation'
+
+describe FaradayMiddleware::Instrumentation do
+  let(:app) { lambda {|env| Faraday::Response.new } }
+  let(:middleware) { described_class.new(app) }
+  let(:events) { [] }
+  let(:env) { faraday_env(:request_headers => Faraday::Utils::Headers.new) }
+
+  def process
+    response = middleware.call(env)
+    response.finish(env)
+    response
+  end
+
+  around do |example|
+    subscriber = ActiveSupport::Notifications.subscribe "request.faraday" do |*args|
+      events << ActiveSupport::Notifications::Event.new(*args)
+    end
+
+    example.run
+
+    ActiveSupport::Notifications.unsubscribe(subscriber)
+  end
+
+  it "instruments the duration of the request" do
+    process
+    expect(events.first.duration).to be > 0
+  end
+
+  it "uses the env as event payload" do
+    process
+    expect(events.first.payload).to eq env
+  end
+end


### PR DESCRIPTION
I wish to use the instrumentation middleware when doing asynchronous requests – in newer versions of Rails it's possible to separately trigger the start and finish stages of an instrumentation event, which makes this rather simple.

The only thing missing from this is exception handling. The [`instrument`](https://github.com/rails/rails/blob/3ffffcc39dec63e2c0e3c57a76c31649c781989e/activesupport/lib/active_support/notifications/instrumenter.rb#L17) method adds information on any exception raised in the block to the `:exception` key in the event payload. However, I'm not sure how to handle this case – if there's an exception, I assume the `on_complete` handlers are not even called.
