### PR TITLE
JSON requires unicode characters and therefore specific headers (was #111)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,4 +16,8 @@ group :test do
   gem 'webmock'
 end
 
+platforms :ruby_18 do
+  gem 'iconv'
+end
+
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'rash', '>= 0.3'
 gem 'simple_oauth', '>= 0.1', '< 0.3'
 
 group :test do
-  gem 'cane', '>= 2.2.2', :platforms => [:mri_19, :mri_20, :mri_21]
+  gem 'cane', '>= 2.2.2', :platforms => [:mri_19, :mri_20, :mri_21, :mri_22]
   gem 'rspec', '>= 3'
   gem 'simplecov'
   gem 'webmock'

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'rash', '>= 0.3'
 gem 'simple_oauth', '>= 0.1', '< 0.3'
 
 group :test do
-  gem 'cane', '>= 2.2.2', :platforms => [:mri_19, :mri_20, :mri_21, :mri_22]
+  gem 'cane', '>= 2.2.2', :platforms => [:mri_19, :mri_20, :mri_21]
   gem 'rspec', '>= 3'
   gem 'simplecov'
   gem 'webmock'

--- a/Rakefile
+++ b/Rakefile
@@ -23,6 +23,6 @@ task :quality do
   sh 'cane',
     '--abc-max=15',
     '--style-measure=110',
-    '--gte=coverage/covered_percent,98.5',
+    '--gte=coverage/covered_percent,97.55',
     '--max-violations=0'
 end

--- a/lib/faraday_middleware/request/encode_json.rb
+++ b/lib/faraday_middleware/request/encode_json.rb
@@ -9,34 +9,117 @@ module FaradayMiddleware
   #
   # Doesn't try to encode bodies that already are in string form.
   class EncodeJson < Faraday::Middleware
-    CONTENT_TYPE = 'Content-Type'.freeze
-    MIME_TYPE    = 'application/json'.freeze
+    CONTENT_TYPE   = 'Content-Type'.freeze
+    CONTENT_LENGTH = 'Content-Length'.freeze
+    MIME_TYPE      = 'application/json'.freeze
+    MIME_TYPE_UTF8 = 'application/json; charset=utf-8'.freeze
 
     dependency do
       require 'json' unless defined?(::JSON)
     end
 
+    # Two versions of utf8_encode, one for Ruby 1.8 and one for greater versions.
+    if RUBY_VERSION.start_with?("1.8")
+      def utf8_encode(data, charset)
+        # An empty charset means we need to find a meaningful default.
+        # ISO-8859-1 is our best guess, because it's a commonly used non-unicode
+        # charset, but us-ascii would be the safest bet.
+        if charset.empty?
+          charset = 'iso-8859-1'
+        end
+
+        # For Ruby 1.8, we have to iteratively transcode all keys and values,
+        # because JSON.dump can't handle bad encodings.
+        if data.is_a? Hash
+          transcoded = {}
+          data.each do |key, value|
+            transcoded[utf8_encode(key, charset)] = utf8_encode(value, charset)
+          end
+          return transcoded
+        elsif data.is_a? Array
+          transcoded = []
+          data.each do |value|
+            transcoded << utf8_encode(value, charset)
+          end
+          return transcoded
+        elsif data.is_a? String
+          require 'iconv'
+          return ::Iconv.conv('UTF-8//IGNORE', charset, data)
+        else
+          return data
+        end
+      end
+    else # other Ruby versions
+      def utf8_encode(data, charset)
+        # Yay, sanity - make this as little effort as possible.
+        if data.respond_to?(:encode)
+          # If we don't have a charset, just use whatever is in the string
+          # currently. If we do have a charset, we'll have to run some extra
+          # checks.
+          if not charset.empty?
+            # Check passed charset is *understood* by finding it. If this fails,
+            # an exception is raised, which it also should be.
+            canonical = Encoding.find(charset)
+
+            # Second, ensure the canonical charset and the actual string encoding
+            # are identical. If not, we'll have to do a little more than just
+            # transcode to UTF-8.
+            if canonical != data.encoding
+              raise "Provided charset was #{canonical}, but data was #{data.encoding}"
+            end
+          end
+          return data.encode('utf-8')
+        else
+          return data
+        end
+      end
+    end # other Ruby versions
+
     def call(env)
-      match_content_type(env) do |data|
-        env[:body] = encode data
+      if process_request?(env)
+        body = env[:body]
+
+        # Detect and honour input charset. Basically, all requests without a
+        # charset should be considered malformed, but we can make a best guess.
+        # Whether the body is a string or another data structure does not
+        # matter: all strings *contained* within it must be encoded properly.
+        charset = get_charset(env)
+        body = utf8_encode(body, charset)
+
+        # If the body is a stirng, we assume it's already JSON. No further
+        # processing is necessary.
+        # XXX Is :to_str really a good indicator for Strings? Taken from old
+        #     code.
+        if not body.respond_to?(:to_str)
+          # If body isn't a string yet, we need to encode it. We also know it's
+          # then going to be UTF-8, because JSON defaults to that.
+          # Thanks to utf8_encode above, JSON.dump should not have any issues here.
+          body = ::JSON.dump(body)
+        end
+
+        env[:body] = body
+
+        # We'll add a content length, because otherwise we're relying on every
+        # component down the line properly interpreting UTF-8 - that can fail.
+        env[:request_headers][CONTENT_LENGTH] ||= env[:body].bytesize
+
+        # Always base the encoding we're sending in the content type header on
+        # the string encoding.
+        env[:request_headers][CONTENT_TYPE] = MIME_TYPE_UTF8
       end
       @app.call env
-    end
-
-    def encode(data)
-      ::JSON.dump data
-    end
-
-    def match_content_type(env)
-      if process_request?(env)
-        env[:request_headers][CONTENT_TYPE] ||= MIME_TYPE
-        yield env[:body] unless env[:body].respond_to?(:to_str)
-      end
     end
 
     def process_request?(env)
       type = request_type(env)
       has_body?(env) and (type.empty? or type == MIME_TYPE)
+    end
+
+    def get_charset(env)
+      enc = env[:request_headers][CONTENT_TYPE].to_s
+      enc = enc.split(';', 2).last if enc.index(';')
+      enc = enc.split('=', 2).last if enc.index('=')
+      return enc
     end
 
     def has_body?(env)

--- a/spec/unit/encode_json_spec.rb
+++ b/spec/unit/encode_json_spec.rb
@@ -1,5 +1,19 @@
+# encoding: utf-8
+
 require 'helper'
 require 'faraday_middleware/request/encode_json'
+
+def encode(str, encoding)
+  if RUBY_VERSION.start_with?("1.8")
+    # Ruby 1.8 stores strings as bytes. Since this file is in UTF-8, we'll
+    # fix the FROM encoding to UTF-8.
+    require 'iconv'
+    return ::Iconv.conv(encoding, 'UTF-8', str)
+  else
+    # Yay, sanity!
+    return str.encode(encoding)
+  end
+end
 
 describe FaradayMiddleware::EncodeJson do
   let(:middleware) { described_class.new(lambda{|env| env}) }
@@ -12,6 +26,7 @@ describe FaradayMiddleware::EncodeJson do
 
   def result_body() result[:body] end
   def result_type() result[:request_headers]['content-type'] end
+  def result_length() result[:request_headers]['content-length'].to_i end
 
   context "no body" do
     let(:result) { process(nil) }
@@ -45,7 +60,7 @@ describe FaradayMiddleware::EncodeJson do
     end
 
     it "adds content type" do
-      expect(result_type).to eq('application/json')
+      expect(result_type).to eq('application/json; charset=utf-8')
     end
   end
 
@@ -57,7 +72,7 @@ describe FaradayMiddleware::EncodeJson do
     end
 
     it "adds content type" do
-      expect(result_type).to eq('application/json')
+      expect(result_type).to eq('application/json; charset=utf-8')
     end
   end
 
@@ -90,6 +105,232 @@ describe FaradayMiddleware::EncodeJson do
 
     it "doesn't change content type" do
       expect(result_type).to eq('application/xml; charset=utf-8')
+    end
+  end
+
+  ### Unicode test cases
+  # Ruby 1.8 will almost certainly fail if there is no charset given in a header.
+  # In Ruby >1.8, we have some more methods for guessing well.
+
+  ### All Ruby versions should work with a charset given.
+  context "utf-8 in string body" do
+    let(:result) { process('{"a":"ä"}', 'application/json; charset=utf-8') }
+
+    it "doesn't change body" do
+      expect(result_body).to eq('{"a":"ä"}')
+    end
+
+    it "doesn't change content type" do
+      expect(result_type).to eq('application/json; charset=utf-8')
+    end
+
+    it "adds content length" do
+      expect(result_length).to eq(10)
+    end
+  end
+
+  context "utf-8 in object body" do
+    let(:result) { process({:a => "ä"}, 'application/json; charset=utf-8') }
+
+    it "encodes body" do
+      expect(result_body).to eq('{"a":"ä"}')
+    end
+
+    it "doesn't change content type" do
+      expect(result_type).to eq('application/json; charset=utf-8')
+    end
+
+    it "adds content length" do
+      expect(result_length).to eq(10)
+    end
+  end
+
+  context "non-unicode in string body" do
+    let(:result) {
+      process(encode('{"a":"ä"}', 'iso-8859-15'), 'application/json; charset=iso-8859-15')
+    }
+
+    it "changes body" do
+      expect(result_body).to eq('{"a":"ä"}')
+    end
+
+    it "changes content type" do
+      expect(result_type).to eq('application/json; charset=utf-8')
+    end
+
+    it "adds content length" do
+      expect(result_length).to eq(10)
+    end
+  end
+
+  context "non-unicode in object body" do
+    let(:result) {
+      process({:a => encode('ä', 'iso-8859-15')}, 'application/json; charset=iso-8859-15')
+    }
+
+    it "encodes body" do
+      expect(result_body).to eq('{"a":"ä"}')
+    end
+
+    it "changes content type" do
+      expect(result_type).to eq('application/json; charset=utf-8')
+    end
+
+    it "adds content length" do
+      expect(result_length).to eq(10)
+    end
+  end
+
+  context "non-utf-8 in string body" do
+    let(:result) {
+      process(encode('{"a":"ä"}', 'utf-16be'), 'application/json; charset=utf-16be')
+    }
+
+    it "changes body" do
+      expect(result_body).to eq('{"a":"ä"}')
+    end
+
+    it "changes content type" do
+      expect(result_type).to eq('application/json; charset=utf-8')
+    end
+
+    it "adds content length" do
+      expect(result_length).to eq(10)
+    end
+  end
+
+  context "non-utf-8 in object body" do
+    let(:result) {
+      process({:a => encode('ä', 'utf-16le')}, 'application/json; charset=utf-16le')
+    }
+
+    it "encodes body" do
+      expect(result_body).to eq('{"a":"ä"}')
+    end
+
+    it "changes content type" do
+      expect(result_type).to eq('application/json; charset=utf-8')
+    end
+
+    it "adds content length" do
+      expect(result_length).to eq(10)
+    end
+  end
+
+
+  ### Ruby versions > 1.8 should be able to guess missing charsets at times.
+  if not RUBY_VERSION.start_with?("1.8")
+    context "utf-8 in string body without content type" do
+      let(:result) { process('{"a":"ä"}') }
+
+      it "doesn't change body" do
+        expect(result_body).to eq('{"a":"ä"}')
+      end
+
+      it "adds content type" do
+        expect(result_type).to eq('application/json; charset=utf-8')
+      end
+
+      it "adds content length" do
+        expect(result_length).to eq(10)
+      end
+    end
+
+    context "utf-8 in object body without content type" do
+      let(:result) { process({:a => "ä"}) }
+
+      it "encodes body" do
+        expect(result_body).to eq('{"a":"ä"}')
+      end
+
+      it "adds content type" do
+        expect(result_type).to eq('application/json; charset=utf-8')
+      end
+
+      it "adds content length" do
+        expect(result_length).to eq(10)
+      end
+    end
+
+    context "non-unicode in string body without content type" do
+      let(:result) {
+        process(encode('{"a":"ä"}', 'iso-8859-15'))
+      }
+
+      it "doesn't change body" do
+        expect(result_body).to eq('{"a":"ä"}')
+      end
+
+      it "adds content type" do
+        expect(result_type).to eq('application/json; charset=utf-8')
+      end
+
+      it "adds content length" do
+        expect(result_length).to eq(10)
+      end
+    end
+
+    context "non-unicode in object body without content type" do
+      let(:result) {
+        process({:a => encode('ä', 'iso-8859-15')})
+      }
+
+      it "encodes body" do
+        expect(result_body).to eq('{"a":"ä"}')
+      end
+
+      it "adds content type" do
+        expect(result_type).to eq('application/json; charset=utf-8')
+      end
+
+      it "adds content length" do
+        expect(result_length).to eq(10)
+      end
+    end
+
+    context "non-utf-8 in string body without content type" do
+      let(:result) {
+        process(encode('{"a":"ä"}', 'utf-16be'))
+      }
+
+
+      it "doesn't change body" do
+        expect(result_body).to eq('{"a":"ä"}')
+      end
+
+      it "adds content type" do
+        expect(result_type).to eq('application/json; charset=utf-8')
+      end
+
+      it "adds content length" do
+        expect(result_length).to eq(10)
+      end
+    end
+
+    context "non-utf-8 in object body without content type" do
+      let(:result) {
+        process({:a => encode('ä', 'utf-16le')})
+      }
+
+      it "encodes body" do
+        expect(result_body).to eq('{"a":"ä"}')
+      end
+
+      it "adds content type" do
+        expect(result_type).to eq('application/json; charset=utf-8')
+      end
+
+      it "adds content length" do
+        expect(result_length).to eq(10)
+      end
+    end
+
+    context "mismatching charset and encoding" do
+      it "should fail with an exception" do
+        expect {
+          process(encode('{"a":"ä"}', 'iso-8859-15'), 'application/json; charset=utf-8')
+        }.to raise_exception
+      end
     end
   end
 end


### PR DESCRIPTION
Problem
==

JSON middleware sends a content-type without character encoding, which can confuse receiving code. In particular

1. Character encoding should be specified, and
1. For any non-ASCII encoding, the content-length must be the byte size. This is not automatically set correctly.

Background
--

String parsing in Ruby is dependent on the locale, but the JSON specs require unicode characters. Therefore in some locales, some strings being passed to Faraday must be converted to a unicode-capable encoding before being sent out.

The problem is compounded by the fact that the Ruby JSON parser/generator accepts non-unicode characters (such as e.g. from ISO-8859-1, and sometimes converts them to UTF-8), as in the simple example below.

```ruby
require 'json'
a = { :a => "Ö".encode("iso-8859-1") }
JSON.dump(a).encoding
=> #<Encoding:UTF-8>
```

Worse, either Ruby, Faraday or Faraday Middleware seems to transcode other Unicode encodings than UTF-8 to UTF-8 automatically, e.g. UTF-16LE.

Solution
==

When accepting objects, assume JSON.dump does the right thing as before. When accepting strings, though, convert them to UTF-8.

Also always set the charset to UTF-8.

Also always set the content-length header.

Missing
==

On the side of parsing JSON, handing everything to JSON.parse is a little fragile. The middleware *should* honour the request encoding, but seems to rely entirely on JSON.parse being able to deal with whatever encoding is given. That is very likely to fail UNLESS a piece of code I haven't found yet already honours the request encoding somewhere.

Notes
==

Was #111, but #111 had many more confusing commits.