### PR TITLE
Add support for a raw deflated stream to Gzip

### DIFF
--- a/lib/faraday_middleware/gzip.rb
+++ b/lib/faraday_middleware/gzip.rb
@@ -51,10 +51,10 @@ module FaradayMiddleware
       # Inflate as a DEFLATE (RFC 1950+RFC 1951) stream
       Zlib::Inflate.inflate(body)
     rescue Zlib::DataError
+      # Fall back to inflating as a "raw" deflate stream which
+      # Microsoft servers return
+      inflate = Zlib::Inflate.new(-Zlib::MAX_WBITS)
       begin
-        # Fall back to inflating as a "raw" deflate stream which
-        # Microsoft servers return
-        inflate = Zlib::Inflate.new(-Zlib::MAX_WBITS)
         inflate.inflate(body)
       ensure
         inflate.close

--- a/lib/faraday_middleware/gzip.rb
+++ b/lib/faraday_middleware/gzip.rb
@@ -48,7 +48,17 @@ module FaradayMiddleware
     end
 
     def inflate(body)
+      # Inflate as a DEFLATE (RFC 1950+RFC 1951) stream
       Zlib::Inflate.inflate(body)
+    rescue Zlib::DataError
+      begin
+        # Fall back to inflating as a "raw" deflate stream which
+        # Microsoft servers return
+        inflate = Zlib::Inflate.new(-Zlib::MAX_WBITS)
+        inflate.inflate(body)
+      ensure
+        inflate.close
+      end
     end
   end
 end

--- a/spec/unit/gzip_spec.rb
+++ b/spec/unit/gzip_spec.rb
@@ -39,6 +39,12 @@ describe FaradayMiddleware::Gzip, :type => :response do
     let(:deflated_body) {
       Zlib::Deflate.deflate(uncompressed_body)
     }
+    let(:raw_deflated_body) {
+      z = Zlib::Deflate.new(Zlib::DEFAULT_COMPRESSION, -Zlib::MAX_WBITS)
+      compressed_body = z.deflate(uncompressed_body, Zlib::FINISH)
+      z.close
+      compressed_body
+    }
 
     shared_examples 'compressed response' do
       it 'uncompresses the body' do
@@ -63,6 +69,13 @@ describe FaradayMiddleware::Gzip, :type => :response do
 
     context 'deflated response' do
       let(:body) { deflated_body }
+      let(:headers) { {'Content-Encoding' => 'deflate', 'Content-Length' => body.length} }
+
+      it_behaves_like 'compressed response'
+    end
+
+    context 'raw deflated response' do
+      let(:body) { raw_deflated_body }
       let(:headers) { {'Content-Encoding' => 'deflate', 'Content-Length' => body.length} }
 
       it_behaves_like 'compressed response'


### PR DESCRIPTION
Currently the Gzip middleware only supports the RFC compliant zlib+deflate stream format, but it should also support the raw deflate stream format adopted by some server implementations like Microsoft IIS and Rack::Deflate.

Here's some references:

- https://en.wikipedia.org/wiki/HTTP_compression#Problems_preventing_the_use_of_HTTP_compression
- https://github.com/rest-client/rest-client/issues/49
- https://github.com/lostisland/faraday_middleware/issues/119