### PR TITLE
Fixed using Caching middleware with async adapter like Typhoeus

### DIFF
--- a/lib/faraday_middleware/response/caching.rb
+++ b/lib/faraday_middleware/response/caching.rb
@@ -78,14 +78,13 @@ module FaradayMiddleware
       if cached_response = cache.read(key)
         finalize_response(cached_response, env)
       else
-        response = @app.call(env)
         # response.status is nil at this point, any checks need to be done inside on_complete block
-        response.on_complete do
+        @app.call(env).on_complete do |response|
           if CACHEABLE_STATUS_CODES.include?(response.status)
             cache.write(key, response)
           end
+          response
         end
-        response
       end
     end
 

--- a/lib/faraday_middleware/response/caching.rb
+++ b/lib/faraday_middleware/response/caching.rb
@@ -79,9 +79,13 @@ module FaradayMiddleware
         finalize_response(cached_response, env)
       else
         response = @app.call(env)
-        if CACHEABLE_STATUS_CODES.include?(response.status)
-          response.on_complete { cache.write(key, response) }
+        # response.status is nil at this point, any checks need to be done inside on_complete block
+        response.on_complete do
+          if CACHEABLE_STATUS_CODES.include?(response.status)
+            cache.write(key, response)
+          end
         end
+        response
       end
     end
 


### PR DESCRIPTION
All checks for response properties need to be done inside on_complete
And need to actually return the response.

Related to the lack of tests for parallel mode: See #100 