### PR TITLE
Added support for vendor content types to EncodeJson

### DIFF
--- a/lib/faraday_middleware/request/encode_json.rb
+++ b/lib/faraday_middleware/request/encode_json.rb
@@ -46,7 +46,7 @@ module FaradayMiddleware
     def request_type(env)
       type = env[:request_headers][CONTENT_TYPE].to_s
       type = type.split(';', 2).first if type.index(';')
-      type
+      type.gsub(/vnd\.\w+\+/,'')
     end
   end
 end


### PR DESCRIPTION
It's necessary for [JSON API](http://jsonapi.org/format/#crud) and likely for other protocols.