### PR TITLE
Add brotli support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'brotli', '>= 0.1.8'
 gem 'hashie', '>= 1.2'
 gem 'jruby-openssl', :platforms => :jruby
 gem 'json', :platforms => [:jruby, :rbx, :ruby_18]

--- a/lib/faraday_middleware/gzip.rb
+++ b/lib/faraday_middleware/gzip.rb
@@ -12,11 +12,12 @@ module FaradayMiddleware
   # - em_http
   class Gzip < Faraday::Middleware
     dependency 'zlib'
+    dependency 'brotli'
 
     ACCEPT_ENCODING = 'Accept-Encoding'.freeze
     CONTENT_ENCODING = 'Content-Encoding'.freeze
     CONTENT_LENGTH = 'Content-Length'.freeze
-    SUPPORTED_ENCODINGS = 'gzip,deflate'.freeze
+    SUPPORTED_ENCODINGS = 'gzip,deflate,br'.freeze
     RUBY_ENCODING = '1.9'.respond_to?(:force_encoding)
 
     def call(env)
@@ -27,6 +28,8 @@ module FaradayMiddleware
           reset_body(response_env, &method(:uncompress_gzip))
         when 'deflate'
           reset_body(response_env, &method(:inflate))
+        when 'br'
+          reset_body(response_env, &method(:brotli_inflate))
         end
       end
     end
@@ -59,6 +62,10 @@ module FaradayMiddleware
       ensure
         inflate.close
       end
+    end
+
+    def brotli_inflate(body)
+      Brotli.inflate(body)
     end
   end
 end

--- a/spec/unit/gzip_spec.rb
+++ b/spec/unit/gzip_spec.rb
@@ -12,7 +12,7 @@ describe FaradayMiddleware::Gzip, :type => :response do
   context 'request' do
     it 'sets the Accept-Encoding request header' do
       env = process('').env
-      expect(env[:request_headers][:accept_encoding]).to eq('gzip,deflate')
+      expect(env[:request_headers][:accept_encoding]).to eq('gzip,deflate,br')
     end
 
     it 'doesnt overwrite existing Accept-Encoding request header' do
@@ -44,6 +44,9 @@ describe FaradayMiddleware::Gzip, :type => :response do
       compressed_body = z.deflate(uncompressed_body, Zlib::FINISH)
       z.close
       compressed_body
+    }
+    let(:brotlied_body) {
+      Brotli.deflate(uncompressed_body)
     }
 
     shared_examples 'compressed response' do
@@ -77,6 +80,13 @@ describe FaradayMiddleware::Gzip, :type => :response do
     context 'raw deflated response' do
       let(:body) { raw_deflated_body }
       let(:headers) { {'Content-Encoding' => 'deflate', 'Content-Length' => body.length} }
+
+      it_behaves_like 'compressed response'
+    end
+
+    context 'brotlied response' do
+      let(:body) { brotlied_body }
+      let(:headers) { {'Content-Encoding' => 'br', 'Content-Length' => body.length } }
 
       it_behaves_like 'compressed response'
     end


### PR DESCRIPTION
Brotli is a new open-source compression algorithm from Google which can
give more dense compression, while compression and decompression speeds
are roughly the same.

Brotli responses are requested by setting `Accept-Encoding: br`.

Transferring less data over the network will typically result in a
faster experience for users.

This change adds support for Brotli decompression of responses.
