### PR TITLE
Replace rash with rash_alt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'multi_xml', '>= 0.5.3'
 gem 'rack', '< 2'
 gem 'rack-cache', '>= 1.1', '< 1.3'
 gem 'rake', '>= 0.9', '< 11'
-gem 'rash', '>= 0.3'
+gem 'rash_alt', '>= 0.4.3'
 gem 'simple_oauth', '>= 0.1', '< 0.3'
 
 group :test do

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Some dependent libraries are needed only when using specific middleware:
 * FaradayMiddleware::ParseXml: "multi_xml"
 * FaradayMiddleware::OAuth: "simple_oauth"
 * FaradayMiddleware::Mashify: "hashie"
-* FaradayMiddleware::Rashify: "rash"
+* FaradayMiddleware::Rashify: "rash_alt" (Make sure to uninstall original rash gem to avoid conflict)
 * FaradayMiddleware::Instrumentation: "activesupport"
 
 Examples

--- a/lib/faraday_middleware/response/rashify.rb
+++ b/lib/faraday_middleware/response/rashify.rb
@@ -6,7 +6,7 @@ module FaradayMiddleware
   class Rashify < Mashify
     dependency do
       require 'rash'
-      self.mash_class = ::Hashie::Rash
+      self.mash_class = ::Hashie::Mash::Rash
     end
   end
 end


### PR DESCRIPTION
Since Hashie have own Rash, [rash gem](https://github.com/tcocca/rash) have problem of conflict namespace. We discussed this from long time ago.
https://github.com/tcocca/rash/issues/9
But there is not any solution, I released [rash_alt gem](https://rubygems.org/gems/rash_alt) for solving out-of-dependency.

faraday_middleware use both hashie and rash, there is problem for out-of-dependency. This pull request solve this problem.
