### PR TITLE
Support non-zulu times in ParseDates Middleware

### DIFF
--- a/lib/faraday_middleware/response/parse_dates.rb
+++ b/lib/faraday_middleware/response/parse_dates.rb
@@ -4,7 +4,7 @@ require "faraday"
 module FaradayMiddleware
   # Parse dates from response body
   class ParseDates < ::Faraday::Response::Middleware
-    ISO_DATE_FORMAT = /\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z\Z/m
+    ISO_DATE_FORMAT = /\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|((\+|-)\d{2}:?\d{2}))\Z/m
 
     def initialize(app, options = {})
       @regexp = options[:match] || ISO_DATE_FORMAT

--- a/spec/unit/parse_dates_spec.rb
+++ b/spec/unit/parse_dates_spec.rb
@@ -13,11 +13,15 @@ describe FaradayMiddleware::ParseDates, :type => :response do
 
   it "parses dates" do
     expect(process({"x" => "2012-02-01T13:14:15Z"}).body["x"].to_s).to eq(parsed)
+    expect(process({"x" => "2012-02-01T15:14:15+02:00"}).body["x"].utc.to_s).to eq(parsed)
+    expect(process({"x" => "2012-02-01T11:14:15-0200"}).body["x"].utc.to_s).to eq(parsed)
   end
 
   it "parses dates with milliseconds" do
     date_str = "2012-02-01T13:14:15.123Z"
+    non_zulu_date_str = "2012-02-01T11:14:15.123-02:00"
     expect(process({"x" => date_str}).body["x"]).to eq(Time.parse(date_str))
+    expect(process({"x" => non_zulu_date_str}).body["x"]).to eq(Time.parse(date_str))
   end
 
   it "parses nested dates in hash" do


### PR DESCRIPTION
While not exhaustive, this expands support to include a larger subset ISO8601 Date formats that specify a time with zone.

In the context of Faraday, I think that this expansion is safe, but that any further assumptions about what constitutes a valid Date / Time would need to be strongly considered.