### PR TITLE
Allow passing options to parser

### DIFF
--- a/lib/faraday_middleware/response/parse_json.rb
+++ b/lib/faraday_middleware/response/parse_json.rb
@@ -7,8 +7,8 @@ module FaradayMiddleware
       require 'json' unless defined?(::JSON)
     end
 
-    define_parser do |body|
-      ::JSON.parse body unless body.strip.empty?
+    define_parser do |body, options|
+      ::JSON.parse(body, options) unless body.strip.empty?
     end
 
     # Public: Override the content-type of the response with "application/json"

--- a/lib/faraday_middleware/response_middleware.rb
+++ b/lib/faraday_middleware/response_middleware.rb
@@ -45,7 +45,7 @@ module FaradayMiddleware
     def parse(body)
       if self.class.parser
         begin
-          self.class.parser.call(body)
+          self.class.parser.call(body, @options)
         rescue StandardError, SyntaxError => err
           raise err if err.is_a? SyntaxError and err.class.name != 'Psych::SyntaxError'
           raise Faraday::Error::ParsingError, err

--- a/spec/unit/parse_json_spec.rb
+++ b/spec/unit/parse_json_spec.rb
@@ -109,4 +109,12 @@ describe FaradayMiddleware::ParseJson, :type => :response do
       expect(response.body).to be_nil
     end
   end
+
+  context "with passing options to the parser" do
+    let(:options) { {:symbolize_names => true } }
+
+    it "correctly parses json body according to specified options" do
+      expect(process('{"a":1}').body).to eq(:a => 1)
+    end
+  end
 end


### PR DESCRIPTION
Added support for passing additional options to parsers. This could be useful to automatically symbolize keys when parsing JSON response (see #122)