### PR TITLE
Include env.response when rescuing ParsingErrors

### DIFF
--- a/lib/faraday_middleware/response_middleware.rb
+++ b/lib/faraday_middleware/response_middleware.rb
@@ -37,6 +37,8 @@ module FaradayMiddleware
     def process_response(env)
       env[:raw_body] = env[:body] if preserve_raw?(env)
       env[:body] = parse(env[:body])
+    rescue Faraday::Error::ParsingError => err
+      raise Faraday::Error::ParsingError.new(err, env[:response])
     end
 
     # Parse the response body.

--- a/spec/unit/parse_json_spec.rb
+++ b/spec/unit/parse_json_spec.rb
@@ -66,6 +66,15 @@ describe FaradayMiddleware::ParseJson, :type => :response do
     end
   end
 
+  it "includes the response on the ParsingError instance" do
+    begin
+      process('{') { |env| env[:response] = Faraday::Response.new }
+      fail 'Parsing should have failed.'
+    rescue Faraday::Error::ParsingError => err
+      expect(err.response).to be_a(Faraday::Response)
+    end
+  end
+
   context "with mime type fix" do
     let(:middleware) {
       app = described_class::MimeTypeFix.new(lambda {|env|


### PR DESCRIPTION
If a `ParsingError` is raised during processing, then attach the `env.response` to the error.

Presented as an alternative to https://github.com/lostisland/faraday/pull/638.