### PR TITLE
Support response serialization in parallel caching

### DIFF
--- a/lib/faraday_middleware/response/caching.rb
+++ b/lib/faraday_middleware/response/caching.rb
@@ -79,11 +79,11 @@ module FaradayMiddleware
         finalize_response(cached_response, env)
       else
         # response.status is nil at this point, any checks need to be done inside on_complete block
-        @app.call(env).on_complete do |response|
-          if CACHEABLE_STATUS_CODES.include?(response.status)
-            cache.write(key, response)
+        @app.call(env).on_complete do |response_env|
+          if CACHEABLE_STATUS_CODES.include?(response_env.status)
+            cache.write(key, response_env.response)
           end
-          response
+          response_env
         end
       end
     end


### PR DESCRIPTION
This is a slight revision to PR #121.

The change made [here](https://github.com/lostisland/faraday_middleware/pull/121/commits/9389fba5f5a15282e50f522271c7372f578b7ba1) causes issues with caches that use serialization (e.g. [redis-activesupport](https://github.com/redis-store/redis-activesupport)). Here's why:

**Original version**
Here, the response object (`Faraday::Response`) returned from `@app.call(env)` is written to cache.
```
response = @app.call(env)
response.on_complete do
  cache.write(key, response)
end
```
**Current version**
Here, the env object (`Faraday::Env`) yielded from `on_complete` is written to cache.
```
@app.call(env).on_complete do |response|
  cache.write(key, response)
end
```

For the purposes of saving a response, these two approaches seem interchangeable. But the problem is that Faraday::Env contains lots of extra attributes, some of which are not naturally serializable (`TypeError - no _dump_data is defined for class FFI::MemoryPointer`). Whether or not this is a problem depends on your cache class implementation, but I imagine calling Marshal.dump when writing an object is very common.

By using `response.response` when writing to cache, we get only the `Faraday::Response` contained within the `Faraday::Env`. The advantages of this are:
* Consistent with cache.write parameters passed in synchronous mode
* No saving of irrelevant env attributes
* Serializable with Marshal.dump!