### PR TITLE
ignores fragments in the `Location` header on redirect responses

### DIFF
--- a/lib/faraday_middleware/response/follow_redirects.rb
+++ b/lib/faraday_middleware/response/follow_redirects.rb
@@ -125,6 +125,7 @@ module FaradayMiddleware
     # URI:HTTP using the `+` operator. Doesn't escape "%" characters so to not
     # risk double-escaping.
     def safe_escape(uri)
+      uri = uri.split('#')[0] # we want to remove the fragment if present
       uri.to_s.gsub(URI_UNSAFE) { |match|
         '%' + match.unpack('H2' * match.bytesize).join('%').upcase
       }

--- a/spec/unit/follow_redirects_spec.rb
+++ b/spec/unit/follow_redirects_spec.rb
@@ -101,7 +101,6 @@ describe FaradayMiddleware::FollowRedirects do
     end
   end
 
-
   it "returns non-redirect response results" do
     expect(connection do |stub|
       stub.get('/found') { [200, {'Content-Type' => 'text/plain'}, 'fin'] }
@@ -144,6 +143,13 @@ describe FaradayMiddleware::FollowRedirects do
     end
 
     expect{ conn.get('/') }.to raise_error(FaradayMiddleware::RedirectLimitReached)
+  end
+
+  it "ignore fragments in the Location header" do
+    expect(connection do |stub|
+      stub.get('/')      { [301, {'Location' => '/found#fragment'}, ''] }
+      stub.get('/found') { [200, {'Content-Type' => 'text/plain'}, 'fin'] }
+    end.get('/').body).to eq 'fin'
   end
 
   [301, 302].each do |code|


### PR DESCRIPTION
fixes #149, #138, #117 and #105