### PR TITLE
Adds Ruby 2.4.0 to travis matrix and removes Ruby 1.9.2 (since we alr…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ bundler_args: --without development
 language: ruby
 rvm:
   - 1.8.7
-  - 1.9.2
   - 1.9.3
-  - '2.0'
-  - '2.1'
-  - '2.2'
-  - '2.3.0'
+  - 2.0
+  - 2.1
+  - 2.2
+  - 2.3.0
+  - 2.4.0
   - jruby-head
   - rbx-2
   - ruby-head
@@ -20,8 +20,6 @@ gemfile:
 matrix:
   exclude:
     - rvm: 1.8.7
-      gemfile: Gemfile
-    - rvm: 1.9.2
       gemfile: Gemfile
   allow_failures:
     - rvm: jruby-head

--- a/lib/faraday_middleware/version.rb
+++ b/lib/faraday_middleware/version.rb
@@ -1,3 +1,3 @@
 module FaradayMiddleware
-  VERSION = "0.10.0" unless defined?(FaradayMiddleware::VERSION)
+  VERSION = "0.11.0" unless defined?(FaradayMiddleware::VERSION)
 end


### PR DESCRIPTION
…eady have 1.9.3)

version bump 0.11.0