### PR TITLE
Allow `write_options` to be specified for FaradayMiddleware::Caching

### DIFF
--- a/spec/unit/caching_spec.rb
+++ b/spec/unit/caching_spec.rb
@@ -78,6 +78,26 @@ describe FaradayMiddleware::Caching do
     end
   end
 
+  context ":write_options" do
+    let(:options) { {:write_options => {:expires_in => 9000 } } }
+
+    it "passes on the options when writing to the cache" do
+      expect(@cache).to receive(:write).with("/",
+                                             instance_of(Faraday::Response),
+                                             options[:write_options])
+      get('/')
+    end
+
+    context "with no :write_options" do
+      let(:options) { {} }
+
+      it "doesn't pass a third options parameter to the cache's #write" do
+        expect(@cache).to receive(:write).with("/", instance_of(Faraday::Response))
+        get('/')
+      end
+    end
+  end
+
   class TestCache < Hash
     def read(key)
       if cached = self[key]
@@ -85,7 +105,7 @@ describe FaradayMiddleware::Caching do
       end
     end
 
-    def write(key, data)
+    def write(key, data, options = nil)
       self[key] = Marshal.dump(data)
     end
 


### PR DESCRIPTION
`FaradayMiddleware::Caching` is configured with a cache with responds to `#read`, `#fetch` and `#write`. Usually, this will be an instance of a class which conforms to the abstract cache store class [`ActiveSupport::Cache::Store`](http://api.rubyonrails.org/classes/ActiveSupport/Cache/Store.html).

In this pattern, the third argument of `#write` is an optional hash of options - for example, you can specify an `expires_in` to set how long until the cache key expires (this is the case where we're interested for a gem I maintain, https://github.com/ejholmes/restforce). Cache stores may support a range of options.

This allows you, when configuring the middleware, to specify a set of `write_options` which will be passed in as this third argument when writing to the cache.

The alternative to this would be passing in some kind of wrapper around your chosen cache store which does this for you, but it feels nicer for the middleware to do it.