### PR TITLE
Add support for passing options to JSON.parse

### DIFF
--- a/lib/faraday_middleware/response/parse_json.rb
+++ b/lib/faraday_middleware/response/parse_json.rb
@@ -8,7 +8,7 @@ module FaradayMiddleware
     end
 
     define_parser do |body, parser_options|
-      ::JSON.parse body unless body.strip.empty?
+      ::JSON.parse(body, parser_options) unless body.strip.empty?
     end
 
     # Public: Override the content-type of the response with "application/json"

--- a/lib/faraday_middleware/response/parse_json.rb
+++ b/lib/faraday_middleware/response/parse_json.rb
@@ -8,9 +8,7 @@ module FaradayMiddleware
     end
 
     define_parser do |body, parser_options|
-      next if body.strip.empty?
-
-      ::JSON.parse(body, parser_options)
+      ::JSON.parse body unless body.strip.empty?
     end
 
     # Public: Override the content-type of the response with "application/json"

--- a/lib/faraday_middleware/response/parse_json.rb
+++ b/lib/faraday_middleware/response/parse_json.rb
@@ -7,8 +7,18 @@ module FaradayMiddleware
       require 'json' unless defined?(::JSON)
     end
 
-    define_parser do |body|
-      ::JSON.parse body unless body.strip.empty?
+    define_parser do |body, options|
+      next if body.strip.empty?
+
+      ::JSON.parse(
+        body,
+        :max_nesting => options[:max_nesting],
+        :allow_nan => options[:allow_nan],
+        :symbolize_names => options[:symbolize_names],
+        :create_additions => options[:create_additions],
+        :object_class => options[:object_class],
+        :array_class => options[:array_class]
+      )
     end
 
     # Public: Override the content-type of the response with "application/json"

--- a/lib/faraday_middleware/response/parse_json.rb
+++ b/lib/faraday_middleware/response/parse_json.rb
@@ -7,18 +7,10 @@ module FaradayMiddleware
       require 'json' unless defined?(::JSON)
     end
 
-    define_parser do |body, options|
+    define_parser do |body, parser_options|
       next if body.strip.empty?
 
-      ::JSON.parse(
-        body,
-        :max_nesting => options[:max_nesting],
-        :allow_nan => options[:allow_nan],
-        :symbolize_names => options[:symbolize_names],
-        :create_additions => options[:create_additions],
-        :object_class => options[:object_class],
-        :array_class => options[:array_class]
-      )
+      ::JSON.parse(body, parser_options)
     end
 
     # Public: Override the content-type of the response with "application/json"

--- a/lib/faraday_middleware/response_middleware.rb
+++ b/lib/faraday_middleware/response_middleware.rb
@@ -47,7 +47,7 @@ module FaradayMiddleware
     def parse(body)
       if self.class.parser
         begin
-          self.class.parser.call(body)
+          self.class.parser.call(body, @options)
         rescue StandardError, SyntaxError => err
           raise err if err.is_a? SyntaxError and err.class.name != 'Psych::SyntaxError'
           raise Faraday::Error::ParsingError, err

--- a/lib/faraday_middleware/response_middleware.rb
+++ b/lib/faraday_middleware/response_middleware.rb
@@ -23,6 +23,7 @@ module FaradayMiddleware
     def initialize(app = nil, options = {})
       super(app)
       @options = options
+      @parser_options = options[:parser_options]
       @content_types = Array(options[:content_type])
     end
 
@@ -47,7 +48,11 @@ module FaradayMiddleware
     def parse(body)
       if self.class.parser
         begin
-          self.class.parser.call(body, @options)
+          if @parser_options
+            self.class.parser.call(body, @parser_options)
+          else
+            self.class.parser.call(body)
+          end
         rescue StandardError, SyntaxError => err
           raise err if err.is_a? SyntaxError and err.class.name != 'Psych::SyntaxError'
           raise Faraday::Error::ParsingError, err

--- a/spec/unit/parse_json_spec.rb
+++ b/spec/unit/parse_json_spec.rb
@@ -124,27 +124,15 @@ describe FaradayMiddleware::ParseJson, :type => :response do
     let(:result) { {} }
     let(:options) do
       {
-        :max_nesting => 22,
-        :allow_nan => true,
-        :symbolize_names => true,
-        :create_additions => false,
-        :object_class => Class,
-        :array_class => Class,
-        :foo => 1234
+        :parser_options => {
+          :symbolize_names => true
+        }
       }
     end
 
     it "passes relevant options to JSON parse" do
       allow(::JSON).to receive(:parse)
-        .with(
-          body,
-          :max_nesting => options[:max_nesting],
-          :allow_nan => options[:allow_nan],
-          :symbolize_names => options[:symbolize_names],
-          :create_additions => options[:create_additions],
-          :object_class => options[:object_class],
-          :array_class => options[:array_class]
-        )
+        .with(body, options[:parser_options])
         .and_return(result)
 
       response = process(body)

--- a/spec/unit/parse_json_spec.rb
+++ b/spec/unit/parse_json_spec.rb
@@ -118,4 +118,37 @@ describe FaradayMiddleware::ParseJson, :type => :response do
       expect(response.body).to be_nil
     end
   end
+
+  context "JSON options" do
+    let(:body) { '{"a": 1}' }
+    let(:result) { {} }
+    let(:options) do
+      {
+        :max_nesting => 22,
+        :allow_nan => true,
+        :symbolize_names => true,
+        :create_additions => false,
+        :object_class => Class,
+        :array_class => Class,
+        :foo => 1234
+      }
+    end
+
+    it "passes relevant options to JSON parse" do
+      allow(::JSON).to receive(:parse)
+        .with(
+          body,
+          :max_nesting => options[:max_nesting],
+          :allow_nan => options[:allow_nan],
+          :symbolize_names => options[:symbolize_names],
+          :create_additions => options[:create_additions],
+          :object_class => options[:object_class],
+          :array_class => options[:array_class]
+        )
+        .and_return(result)
+
+      response = process(body)
+      expect(response.body).to be(result)
+    end
+  end
 end


### PR DESCRIPTION
This should fix #124 and allow all options to be passed to JSON.parse, it felt best to pass the options to the parse proc instead of overriding the parse method which was my second option and looks to be the way that the multijson middleware does it (which I am also open to doing).

Passing the options to the proc should be a non breaking change as any existing parsing middleware will continue to work as before and if required they will have access to the options argument.