### PR TITLE
Parse YAML safely

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem 'rack-cache', '>= 1.1', '< 1.3'
 gem 'rake', '>= 0.9', '< 11'
 gem 'rash', '>= 0.3'
 gem 'simple_oauth', '>= 0.1', '< 0.3'
+gem 'safe_yaml'
 
 group :test do
   gem 'cane', '>= 2.2.2', :platforms => [:mri_19, :mri_20, :mri_21]


### PR DESCRIPTION
An issue from June 2014, https://github.com/lostisland/faraday_middleware/issues/92, raises the risks of the current `FaradayMiddleware::ParseYaml` middleware which uses `YAML.load`. This method is very unsafe and exposes you to remote code execution - see https://github.com/ruby/psych/issues/119 for discussion.

At the time, @mislav decided not to make this change to avoid messing with backwards compatability.

I would suggest that we should revisit this decision - the risks of this are very high, very few people are using this middleware most likely, and it doesn't seem unreasonable to break this
as long as we are clear on the change in the changelog.

This does that by using Ruby's built-in `Psych.safe_load` for Ruby 2.0.0 and onwards, or otherwise uses the `safe_yaml` gem for earlier versions.