### PR TITLE
Handle responses with missing Location header

### DIFF
--- a/lib/faraday_middleware/response/follow_redirects.rb
+++ b/lib/faraday_middleware/response/follow_redirects.rb
@@ -89,7 +89,7 @@ module FaradayMiddleware
     end
 
     def update_env(env, request_body, response)
-      env[:url] += safe_escape(response['location'])
+      env[:url] += safe_escape(response['location'] || '')
 
       if convert_to_get?(response)
         env[:method] = :get

--- a/spec/unit/follow_redirects_spec.rb
+++ b/spec/unit/follow_redirects_spec.rb
@@ -152,6 +152,18 @@ describe FaradayMiddleware::FollowRedirects do
     end.get('/').body).to eq 'fin'
   end
 
+  described_class::REDIRECT_CODES.each do |code|
+    context "for an HTTP #{code} response" do
+      it "raises a FaradayMiddleware::RedirectLimitReached when Location header is missing" do
+        conn = connection do |stub|
+          stub.get('/') { [code, {}, ''] }
+        end
+
+        expect{ conn.get('/') }.to raise_error(FaradayMiddleware::RedirectLimitReached)
+      end
+    end
+  end
+
   [301, 302].each do |code|
     context "for an HTTP #{code} response" do
       it_behaves_like 'a successful redirection', code


### PR DESCRIPTION
This restores the behaviour we had prior to https://github.com/lostisland/faraday_middleware/commit/34c5bc1159566a5e156b75cd50f2cf4c5f00ce02.

Close #158.