### PR TITLE
Removes support for ruby < 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 bundler_args: --without development
 language: ruby
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0
   - 2.1
@@ -11,20 +10,13 @@ rvm:
   - 2.4.0
   - jruby-head
   - rbx-2
-  - ruby-head
 gemfile:
   - Gemfile
-  - Gemfile-0.7.rb
-  - Gemfile-0.8.rb
   - Gemfile-0.9.rb
 matrix:
-  exclude:
-    - rvm: 1.8.7
-      gemfile: Gemfile
   allow_failures:
     - rvm: jruby-head
     - rvm: rbx-2
-    - rvm: ruby-head
   fast_finish: true
 deploy:
   provider: rubygems
@@ -34,3 +26,5 @@ deploy:
   on:
     tags: true
     repo: lostisland/faraday_middleware
+    rvm: 2.4.0
+    gemfile: Gemfile


### PR DESCRIPTION
Aligns Travis with `faraday`