### PR TITLE
README: drop explanation about "ruby < 1.9"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ Dependencies
 
 Some dependent libraries are needed only when using specific middleware:
 
-* FaradayMiddleware::EncodeJson & FaradayMiddleware::ParseJson: "json"
-  for ruby older than 1.9
 * FaradayMiddleware::ParseXml: "multi_xml"
 * FaradayMiddleware::OAuth: "simple_oauth"
 * FaradayMiddleware::Mashify: "hashie"


### PR DESCRIPTION
This PR removes a part of the README, which assisted with "ruby < 1.9", which after 0.12 release is not supported by the gem, anyway.

  - [ci skip]