### PR TITLE
README: Dependent library list as table

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ Some dependent libraries are needed only when using specific middleware:
 
 | Middleware                  | Library        | Notes |
 | --------------------------- | -------------- | ----- |
-| [FaradayMiddleware::ParseXml](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/response/parse_xml.rb) | `multi_xml`    |       |
+| [FaradayMiddleware::Instrumentation](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/instrumentation.rb) | `activesupport` |       |
 | [FaradayMiddleware::OAuth](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/request/oauth.rb)    | `simple_oauth` |       |
+| [FaradayMiddleware::ParseXml](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/response/parse_xml.rb) | `multi_xml`    |       |
+| [FaradayMiddleware::ParseYaml](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/response/parse_yaml.rb)  | `safe_yaml`     | Not backwards compatible with versions of this middleware prior to `faraday_middleware` v0.12. See code comments for alternatives. |
 | [FaradayMiddleware::Mashify](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/response/mashify.rb)  | `hashie`       |       |
 | [FaradayMiddleware::Rashify](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/response/rashify.rb)  | `rash_alt`     | Make sure to uninstall original `rash` gem to avoid conflict. |
-| [FaradayMiddleware::ParseYaml](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/response/parse_yaml.rb)  | `safe_yaml`     | Not backwards compatible with versions of this middleware prior to `faraday_middleware` v0.12. See code comments for alternatives. |
-| [FaradayMiddleware::Instrumentation](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/instrumentation.rb) | `activesupport` |       |
 
 Examples
 --------

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ Some dependent libraries are needed only when using specific middleware:
 
 | Middleware                  | Library        | Notes |
 | --------------------------- | -------------- | ----- |
-| [FaradayMiddleware::Instrumentation](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/instrumentation.rb) | `activesupport` |       |
-| [FaradayMiddleware::OAuth](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/request/oauth.rb)    | `simple_oauth` |       |
-| [FaradayMiddleware::ParseXml](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/response/parse_xml.rb) | `multi_xml`    |       |
-| [FaradayMiddleware::ParseYaml](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/response/parse_yaml.rb)  | `safe_yaml`     | Not backwards compatible with versions of this middleware prior to `faraday_middleware` v0.12. See code comments for alternatives. |
-| [FaradayMiddleware::Mashify](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/response/mashify.rb)  | `hashie`       |       |
-| [FaradayMiddleware::Rashify](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/response/rashify.rb)  | `rash_alt`     | Make sure to uninstall original `rash` gem to avoid conflict. |
+| [FaradayMiddleware::Instrumentation](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/instrumentation.rb) | [`activesupport`](https://rubygems.org/gems/activesupport) |       |
+| [FaradayMiddleware::OAuth](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/request/oauth.rb)    | [`simple_oauth`](https://rubygems.org/gems/simple_oauth) |       |
+| [FaradayMiddleware::ParseXml](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/response/parse_xml.rb) | [`multi_xml`](https://rubygems.org/gems/multi_xml)    |       |
+| [FaradayMiddleware::ParseYaml](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/response/parse_yaml.rb)  | [`safe_yaml`](https://rubygems.org/gems/safe_yaml)     | Not backwards compatible with versions of this middleware prior to `faraday_middleware` v0.12. See code comments for alternatives. |
+| [FaradayMiddleware::Mashify](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/response/mashify.rb)  | [`hashie`](https://rubygems.org/gems/hashie)       |       |
+| [FaradayMiddleware::Rashify](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/response/rashify.rb)  | [`rash_alt`](https://rubygems.org/gems/rash_alt)     | Make sure to uninstall original `rash` gem to avoid conflict. |
 
 Examples
 --------

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Dependencies
 
 Some dependent libraries are needed only when using specific middleware:
 
-| Middleware                  | Library | Notes |
-| --------------------------- | ------- | ----- |
-| FaradayMiddleware::ParseXml | `multi_xml` | |
-| FaradayMiddleware::OAuth    | `simple_oauth` | |
-| FaradayMiddleware::Mashify  | `hashie` | |
-| FaradayMiddleware::Rashify  | `rash_alt` | Make sure to uninstall original `rash` gem to avoid conflict.  |
-| FaradayMiddleware::Instrumentation | `activesupport` | |
+| Middleware                  | Library        | Notes |
+| --------------------------- | -------------- | ----- |
+| FaradayMiddleware::ParseXml | `multi_xml`    |       |
+| FaradayMiddleware::OAuth    | `simple_oauth` |       |
+| FaradayMiddleware::Mashify  | `hashie`       |       |
+| FaradayMiddleware::Rashify  | `rash_alt`     | Make sure to uninstall original `rash` gem to avoid conflict. |
+| FaradayMiddleware::Instrumentation | `activesupport` |       |
 
 Examples
 --------

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Some dependent libraries are needed only when using specific middleware:
 | [FaradayMiddleware::OAuth](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/request/oauth.rb)    | `simple_oauth` |       |
 | [FaradayMiddleware::Mashify](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/response/mashify.rb)  | `hashie`       |       |
 | [FaradayMiddleware::Rashify](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/response/rashify.rb)  | `rash_alt`     | Make sure to uninstall original `rash` gem to avoid conflict. |
+| [FaradayMiddleware::ParseYaml](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/response/parse_yaml.rb)  | `safe_yaml`     | Not backwards compatible with versions of this middleware prior to `faraday_middleware` v0.12. See code comments for alternatives. |
 | [FaradayMiddleware::Instrumentation](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/instrumentation.rb) | `activesupport` |       |
 
 Examples

--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@ Dependencies
 
 Some dependent libraries are needed only when using specific middleware:
 
-* FaradayMiddleware::ParseXml: "multi_xml"
-* FaradayMiddleware::OAuth: "simple_oauth"
-* FaradayMiddleware::Mashify: "hashie"
-* FaradayMiddleware::Rashify: "rash_alt" (Make sure to uninstall original rash gem to avoid conflict)
-* FaradayMiddleware::Instrumentation: "activesupport"
+| Middleware                  | Library | Notes |
+| --------------------------- | ------- | ----- |
+| FaradayMiddleware::ParseXml | `multi_xml` | |
+| FaradayMiddleware::OAuth    | `simple_oauth` | |
+| FaradayMiddleware::Mashify  | `hashie` | |
+| FaradayMiddleware::Rashify  | `rash_alt` | Make sure to uninstall original `rash` gem to avoid conflict.  |
+| FaradayMiddleware::Instrumentation | `activesupport` | |
 
 Examples
 --------

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Some dependent libraries are needed only when using specific middleware:
 
 | Middleware                  | Library        | Notes |
 | --------------------------- | -------------- | ----- |
-| FaradayMiddleware::ParseXml | `multi_xml`    |       |
-| FaradayMiddleware::OAuth    | `simple_oauth` |       |
-| FaradayMiddleware::Mashify  | `hashie`       |       |
-| FaradayMiddleware::Rashify  | `rash_alt`     | Make sure to uninstall original `rash` gem to avoid conflict. |
-| FaradayMiddleware::Instrumentation | `activesupport` |       |
+| [FaradayMiddleware::ParseXml](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/response/parse_xml.rb) | `multi_xml`    |       |
+| [FaradayMiddleware::OAuth](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/request/oauth.rb)    | `simple_oauth` |       |
+| [FaradayMiddleware::Mashify](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/response/mashify.rb)  | `hashie`       |       |
+| [FaradayMiddleware::Rashify](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/response/rashify.rb)  | `rash_alt`     | Make sure to uninstall original `rash` gem to avoid conflict. |
+| [FaradayMiddleware::Instrumentation](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/instrumentation.rb) | `activesupport` |       |
 
 Examples
 --------


### PR DESCRIPTION
This formatting and documenting PR presents the optional dependent libraries as a table.


- [x] links to the middlewares in the repo
- [x] links to the rubygems' homepages
- [x] add a line about `safe_yaml` supporting the `ParseYaml < ResponseMiddleware`