### PR TITLE
[docs] Avoid YARD warnings: define empty Faraday module, classes

### DIFF
--- a/lib/faraday_middleware/backwards_compatibility.rb
+++ b/lib/faraday_middleware/backwards_compatibility.rb
@@ -1,15 +1,18 @@
 # deprecated constants
 
-Faraday::Request.class_eval do
-  autoload :OAuth,        'faraday_middleware/request/oauth'
-  autoload :OAuth2,       'faraday_middleware/request/oauth2'
+module Faraday
+  class Request
+    autoload :OAuth,        'faraday_middleware/request/oauth'
+    autoload :OAuth2,       'faraday_middleware/request/oauth2'
+  end
+
+  class Response
+    autoload :Mashify,      'faraday_middleware/response/mashify'
+    autoload :Rashify,      'faraday_middleware/response/rashify'
+    autoload :ParseJson,    'faraday_middleware/response/parse_json'
+    autoload :ParseXml,     'faraday_middleware/response/parse_xml'
+    autoload :ParseMarshal, 'faraday_middleware/response/parse_marshal'
+    autoload :ParseYaml,    'faraday_middleware/response/parse_yaml'
+  end
 end
 
-Faraday::Response.class_eval do
-  autoload :Mashify,      'faraday_middleware/response/mashify'
-  autoload :Rashify,      'faraday_middleware/response/rashify'
-  autoload :ParseJson,    'faraday_middleware/response/parse_json'
-  autoload :ParseXml,     'faraday_middleware/response/parse_xml'
-  autoload :ParseMarshal, 'faraday_middleware/response/parse_marshal'
-  autoload :ParseYaml,    'faraday_middleware/response/parse_yaml'
-end


### PR DESCRIPTION
This PR adds empty modules and classes, to avoid YARD warnings, and to complete the generated documentation.

![screenshot 2017-09-05 21 39 26](https://user-images.githubusercontent.com/211/30080132-cdac69b4-9282-11e7-8c9e-372ae090b1d7.png)
