### PR TITLE
Disable hashie property override warnings

### DIFF
--- a/lib/faraday_middleware/response/mashify.rb
+++ b/lib/faraday_middleware/response/mashify.rb
@@ -10,9 +10,19 @@ module FaradayMiddleware
       attr_accessor :mash_class
     end
 
+    # Private: Disables Hashie warnings about overriding class properties
+    # with json attributes.
+    require 'hashie/mash'
+    class Mash < Hashie::Mash
+      disable_warnings
+
+      def new(body)
+        super.new(body)
+      end
+    end
+
     dependency do
-      require 'hashie/mash'
-      self.mash_class = ::Hashie::Mash
+      self.mash_class = ::FaradayMiddleware::Mashify::Mash
     end
 
     def initialize(app = nil, options = {})


### PR DESCRIPTION
Hashie recently introduced a change that warns if you construct a
Hashie::Mash with properties which override an existing method. This
can come about with json that contains 'zip' (and other conflicting
names).

There are other gems starting to do the same. https://github.com/chef/chef-zero/pull/276 

https://github.com/intridea/hashie/issues/423
https://github.com/intridea/hashie/blob/master/UPGRADING.md#upgrading-to-352