### PR TITLE
Adds support for following redirections based on HTML meta refresh tag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ group :test do
   gem 'simplecov', '~> 0.12.0'
   gem 'webmock', '< 2'
   gem 'addressable', '< 2.4'
+  gem 'nokogiri'
 end
 
 gemspec


### PR DESCRIPTION
I was wondering about following redirects based on HTTP meta refresh tags, then I found an issue (https://github.com/lostisland/faraday_middleware/issues/172) from someone that was needing the same.

Then I implemented the parameter `follow_meta_refresh` at `FaradayMiddleware::FollowRedirects`.