### PR TITLE
Add the Faraday::Response object to parsing errors

### DIFF
--- a/lib/faraday_middleware/response_middleware.rb
+++ b/lib/faraday_middleware/response_middleware.rb
@@ -51,7 +51,7 @@ module FaradayMiddleware
           self.class.parser.call(body, @parser_options)
         rescue StandardError, SyntaxError => err
           raise err if err.is_a? SyntaxError and err.class.name != 'Psych::SyntaxError'
-          raise Faraday::Error::ParsingError, err
+          raise Faraday::Error::ParsingError.new(err, body)
         end
       else
         body

--- a/spec/unit/parse_xml_spec.rb
+++ b/spec/unit/parse_xml_spec.rb
@@ -69,6 +69,14 @@ describe FaradayMiddleware::ParseXml, :type => :response do
     end
   end
 
+  it "includes a response object when throwing parsing error" do
+    data = 'invalid_xml'
+    expect{ process(data) }.to raise_error { |error|
+      expect(error).to be_a(Faraday::Error::ParsingError)
+      expect(error.cause.response).to eq(data)
+    }
+  end
+
   context "MultiXml options" do
     let(:options) do
       {


### PR DESCRIPTION
It can be useful to have the raw body and other information
available on the response object when catching parsing errors.