### PR TITLE
Clear Authorization header when redirecting cross-site

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ group :test do
   gem 'simplecov', '~> 0.12.0'
   gem 'webmock', '< 2'
   gem 'addressable', '< 2.4'
-  gem 'sinatra'
 end
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ group :test do
   gem 'simplecov', '~> 0.12.0'
   gem 'webmock', '< 2'
   gem 'addressable', '< 2.4'
+  gem 'sinatra'
 end
 
 gemspec

--- a/lib/faraday_middleware/response/follow_redirects.rb
+++ b/lib/faraday_middleware/response/follow_redirects.rb
@@ -100,7 +100,7 @@ module FaradayMiddleware
     def update_env(env, request_body, response)
       redirect_from_url = env[:url].to_s
       redirect_to_url = safe_escape(response['location'] || '')
-      env[:url] += safe_escape(response['location'] || '')
+      env[:url] += redirect_to_url
 
       if convert_to_get?(response)
         env[:method] = :get

--- a/lib/faraday_middleware/response/follow_redirects.rb
+++ b/lib/faraday_middleware/response/follow_redirects.rb
@@ -109,7 +109,7 @@ module FaradayMiddleware
         env[:body] = request_body
       end
 
-      env = clear_authorization_header(env, redirect_from_url, redirect_to_url)
+      clear_authorization_header(env, redirect_from_url, redirect_to_url)
 
       ENV_TO_CLEAR.each {|key| env.delete key }
 

--- a/lib/faraday_middleware/response/follow_redirects.rb
+++ b/lib/faraday_middleware/response/follow_redirects.rb
@@ -61,8 +61,8 @@ module FaradayMiddleware
     #                                  cookies to be kept, or :all to keep
     #                                  all cookies (default: []).
     #     :clear_authorization_header - A Boolean indicating whether the request
-    #                                 Authorization header should be cleared on
-    #                                 redirects (default: false)
+    #                                  Authorization header should be cleared on
+    #                                  redirects (default: true)
     def initialize(app, options = {})
       super(app)
       @options = options
@@ -143,7 +143,7 @@ module FaradayMiddleware
     end
 
     def clear_authorization_header?
-      @options.fetch(:clear_authorization_header, false)
+      @options.fetch(:clear_authorization_header, true)
     end
   end
 end

--- a/lib/faraday_middleware/response/follow_redirects.rb
+++ b/lib/faraday_middleware/response/follow_redirects.rb
@@ -149,7 +149,6 @@ module FaradayMiddleware
       return env unless @options.fetch(:clear_authorization_header, true)
 
       env[:request_headers].delete(AUTH_HEADER)
-      env
     end
 
     def redirect_to_same_host?(from_url, to_url)

--- a/lib/faraday_middleware/response/follow_redirects.rb
+++ b/lib/faraday_middleware/response/follow_redirects.rb
@@ -109,7 +109,7 @@ module FaradayMiddleware
         env[:body] = request_body
       end
 
-      env[:request_headers].delete(AUTH_HEADER) if clear_authorization_header?(redirect_from_url, redirect_to_url)
+      env = clear_authorization_header(env, redirect_from_url, redirect_to_url)
 
       ENV_TO_CLEAR.each {|key| env.delete key }
 
@@ -144,9 +144,12 @@ module FaradayMiddleware
       }
     end
 
-    def clear_authorization_header?(from_url, to_url)
-      return false if redirect_to_same_host?(from_url, to_url)
-      @options.fetch(:clear_authorization_header, true)
+    def clear_authorization_header(env, from_url, to_url)
+      return env if redirect_to_same_host?(from_url, to_url)
+      return env unless @options.fetch(:clear_authorization_header, true)
+
+      env[:request_headers].delete(AUTH_HEADER)
+      env
     end
 
     def redirect_to_same_host?(from_url, to_url)

--- a/spec/unit/follow_redirects_spec.rb
+++ b/spec/unit/follow_redirects_spec.rb
@@ -1,7 +1,6 @@
 require 'helper'
 require 'faraday_middleware/response/follow_redirects'
 require 'faraday'
-require 'sinatra/base'
 
 # expose a method in Test adapter that should have been public
 Faraday::Adapter::Test::Stubs.class_eval { public :new_stub }
@@ -176,111 +175,102 @@ describe FaradayMiddleware::FollowRedirects do
             [200, {'Content-Type' => 'text/plain'}, env[:request_headers]['Authorization']]
           }
         end
-
         response = conn.get('/redirect') { |req|
           req.headers['Authorization'] = 'success'
         }
 
-        expect(response.body).to eq('success')
+        expect(response.body).to eq 'success'
       end
     end
 
     context "is true" do
-      class RedirectToMock < Sinatra::Base
-        get '/found' do
-          request.env["HTTP_AUTHORIZATION"]
-        end
-      end
-
-      let(:conn) do
-        Faraday.new do |conn|
-          conn.use FaradayMiddleware::FollowRedirects
-          conn.adapter Faraday.default_adapter
-        end
-      end
-
       context "redirect to same host" do
         it "redirects with the original authorization headers" do
-          class RedirectFromSameHostMock < Sinatra::Base
-            get '/redirect' do
-              redirect '/found'
+          conn = connection do |stub|
+            stub.get('http://localhost/redirect') do
+              [301, {'Location' => '/found'}, '']
+            end
+            stub.get('http://localhost/found') do |env|
+              [200, {}, env.request_headers["Authorization"]]
             end
           end
-          stub_request(:get, 'http://localhost/redirect').to_rack(RedirectFromSameHostMock)
-          stub_request(:get, 'http://localhost/found').to_rack(RedirectToMock)
-
-          response = conn.get('http://localhost/redirect') { |req|
+          response = conn.get('http://localhost/redirect') do |req|
             req.headers['Authorization'] = 'success'
-          }
-          expect(response.body).to eq('success')
+          end
+
+          expect(response.body).to eq 'success'
         end
       end
 
       context "redirect to same host with explicitly port" do
         it "redirects with the original authorization headers" do
-          class RedirectFromSameHostMock < Sinatra::Base
-            get '/redirect' do
-              redirect 'http://localhost:80/found'
+          conn = connection do |stub|
+            stub.get('http://localhost/redirect') do
+              [301, {'Location' => 'http://localhost:80/found'}, '']
+            end
+            stub.get('http://localhost/found') do |env|
+              [200, {}, env.request_headers["Authorization"]]
             end
           end
-          stub_request(:get, 'http://localhost/redirect').to_rack(RedirectFromSameHostMock)
-          stub_request(:get, 'http://localhost/found').to_rack(RedirectToMock)
-
           response = conn.get('http://localhost/redirect') { |req|
             req.headers['Authorization'] = 'success'
           }
-          expect(response.body).to eq('success')
+
+          expect(response.body).to eq 'success'
         end
       end
 
       context "redirect to different scheme" do
         it "redirects without original authorization headers" do
-          class RedirectFromDifferentSchemeMock < Sinatra::Base
-            get '/redirect' do
-              redirect 'https://localhost2/found'
+          conn = connection do |stub|
+            stub.get('http://localhost/redirect') do
+              [301, {'Location' => 'https://localhost2/found'}, '']
+            end
+            stub.get('https://localhost2/found') do |env|
+              [200, {}, env.request_headers["Authorization"]]
             end
           end
-          stub_request(:get, 'http://localhost/redirect').to_rack(RedirectFromDifferentSchemeMock)
-          stub_request(:get, 'https://localhost2/found').to_rack(RedirectToMock)
-
           response = conn.get('http://localhost/redirect') { |req|
             req.headers['Authorization'] = 'failed'
           }
-          expect(response.body).to eq ''
+
+          expect(response.body).to eq nil
         end
       end
 
       context "redirect to different host" do
         it "redirects without original authorization headers" do
-          class RedirectFromDifferentHostMock < Sinatra::Base
-            get '/redirect' do
-              redirect 'http://localhost2/found'
+          conn = connection do |stub|
+            stub.get('http://localhost/redirect') do
+              [301, {'Location' => 'http://localhost2/found'}, '']
+            end
+            stub.get('https://localhost2/found') do |env|
+              [200, {}, env.request_headers["Authorization"]]
             end
           end
-          stub_request(:get, 'http://localhost/redirect').to_rack(RedirectFromDifferentHostMock)
-          stub_request(:get, 'http://localhost2/found').to_rack(RedirectToMock)
-
           response = conn.get('http://localhost/redirect') { |req|
             req.headers['Authorization'] = 'failed'
           }
-          expect(response.body).to eq ''
+
+          expect(response.body).to eq nil
         end
       end
 
       context "redirect to different port" do
         it "redirects without original authorization headers" do
-          class RedirectFromDifferentPortMock < Sinatra::Base
-            get '/redirect' do
-              redirect 'http://localhost:9091/found'
+          conn = connection do |stub|
+            stub.get('http://localhost:9090/redirect') do
+              [301, {'Location' => 'http://localhost:9091/found'}, '']
+            end
+            stub.get('http://localhost:9091/found') do |env|
+              [200, {}, env.request_headers["Authorization"]]
             end
           end
-          stub_request(:get, 'http://localhost:9090/redirect').to_rack(RedirectFromDifferentPortMock)
-          stub_request(:get, 'http://localhost:9091/found').to_rack(RedirectToMock)
-
           response = conn.get('http://localhost:9090/redirect') { |req|
             req.headers['Authorization'] = 'failed'
           }
-          expect(response.body).to eq ''
+
+          expect(response.body).to eq nil
         end
       end
     end

--- a/spec/unit/follow_redirects_spec.rb
+++ b/spec/unit/follow_redirects_spec.rb
@@ -202,6 +202,25 @@ describe FaradayMiddleware::FollowRedirects do
         expect(response.body).to be_nil
       end
     end
+
+    context "is not specified" do
+      it "redirects without original authorization headers" do
+        conn = connection() do |stub|
+          stub.get('/redirect') {
+            [301, {'Location' => '/found'}, '']
+          }
+          stub.get('/found') { |env|
+            [200, {'Content-Type' => 'text/plain'}, env[:request_headers]['Authorization']]
+          }
+        end
+
+        response = conn.get('/redirect') { |req|
+          req.headers['Authorization'] = 'failed'
+        }
+
+        expect(response.body).to be_nil
+      end
+    end
   end
 
   [301, 302].each do |code|


### PR DESCRIPTION
Fixed the issue that Authorization header remains during redirect to cross-site. 

This PR is related to #81. I added the commit that clear header only redirect to cross-site and that spec.
