### PR TITLE
Ruby 2.7 warns on Proc.new with no block.

### DIFF
--- a/lib/faraday_middleware/response_middleware.rb
+++ b/lib/faraday_middleware/response_middleware.rb
@@ -10,8 +10,8 @@ module FaradayMiddleware
     end
 
     # Store a Proc that receives the body and returns the parsed result.
-    def self.define_parser(parser = nil)
-      @parser = parser || Proc.new
+    def self.define_parser(parser = nil, &block)
+      @parser = parser || block if block_given?
     end
 
     def self.inherited(subclass)


### PR DESCRIPTION
I got the following warnings with Ruby 2.7.

```
faraday_middleware-0.13.1/lib/faraday_middleware/response_middleware.rb:14: warning: Capturing the given block using Proc.new
is deprecated; use `&block` instead
```
