### PR TITLE
Fix support for empty bodies having Content-Encoding Gzip

### DIFF
--- a/spec/unit/gzip_spec.rb
+++ b/spec/unit/gzip_spec.rb
@@ -49,6 +49,9 @@ describe FaradayMiddleware::Gzip, :type => :response do
     let(:brotlied_body) {
       Brotli.deflate(uncompressed_body)
     }
+    let(:empty_body) {
+      ""
+    }
 
     shared_examples 'compressed response' do
       it 'uncompresses the body' do
@@ -90,6 +93,19 @@ describe FaradayMiddleware::Gzip, :type => :response do
       let(:headers) { {'Content-Encoding' => 'br', 'Content-Length' => body.length } }
 
       it_behaves_like 'compressed response'
+    end unless jruby?
+
+    context 'empty response' do
+      let(:body) { empty_body }
+      let(:headers) { {'Content-Encoding' => 'gzip', 'Content-Length' => body.length } }
+
+      it 'sets the Content-Length' do
+        expect(process(body).headers['Content-Length']).to eq(empty_body.length)
+      end
+
+      it 'removes the Content-Encoding' do
+        expect(process(body).headers['Content-Encoding']).to be_nil
+      end
     end unless jruby?
 
     context 'identity response' do

--- a/spec/unit/gzip_spec.rb
+++ b/spec/unit/gzip_spec.rb
@@ -106,7 +106,7 @@ describe FaradayMiddleware::Gzip, :type => :response do
       it 'removes the Content-Encoding' do
         expect(process(body).headers['Content-Encoding']).to be_nil
       end
-    end unless jruby?
+    end
 
     context 'identity response' do
       let(:body) { uncompressed_body }


### PR DESCRIPTION
Sometimes empty bodies can be received together with a Content-Encoding of, for example, "gzip". I've come across this a few times working with external API:s which send a 304 (Do not modify), together with a empty body and Content-Encoding "Gzip".

With these changes, Faraday won't raise an unknown gzip format exception, but rather just not try to decompress the body.

Example of similar fix in okhttp: https://github.com/square/okhttp/issues/268