### PR TITLE
Update to faraday 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ rvm:
   - 2.4
   - 2.5.0
   - 2.6.3
-gemfile: Gemfile
 matrix:
   fast_finish: true
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,20 +6,8 @@ rvm:
   - 2.4
   - 2.5.0
   - 2.6.3
-  - jruby-head
-  - rbx-2
-gemfile:
-  - Gemfile
-  - Gemfile-0.9.rb
+gemfile: Gemfile
 matrix:
-  exclude:
-    - rvm: 2.4
-      gemfile: Gemfile-0.9.rb
-    - rvm: 2.5.0
-      gemfile: Gemfile-0.9.rb
-  allow_failures:
-    - rvm: jruby-head
-    - rvm: rbx-2
   fast_finish: true
 deploy:
   provider: rubygems

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@ bundler_args: --without development
 language: ruby
 before_install: gem install bundler -v '<2'
 rvm:
-  - 1.9.3
-  - 2.0
-  - 2.1
-  - 2.2
   - 2.3
   - 2.4
   - 2.5.0

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org'
 
 gem 'brotli', '>= 0.1.8', platforms: :mri
 gem 'hashie', '>= 1.2'
-gem 'jruby-openssl', platforms: :jruby
 gem 'json', '< 3'
 gem 'multi_xml', '>= 0.5.3'
 gem 'rack', '< 2'

--- a/Gemfile-0.7.rb
+++ b/Gemfile-0.7.rb
@@ -1,3 +1,0 @@
-eval File.read(File.expand_path('../Gemfile', __FILE__))
-
-gem 'faraday', '~> 0.7.4'

--- a/Gemfile-0.8.rb
+++ b/Gemfile-0.8.rb
@@ -1,3 +1,0 @@
-eval File.read(File.expand_path('../Gemfile', __FILE__))
-
-gem 'faraday', '~> 0.8.8'

--- a/Gemfile-0.9.rb
+++ b/Gemfile-0.9.rb
@@ -1,3 +1,0 @@
-eval File.read(File.expand_path('../Gemfile', __FILE__))
-
-gem 'faraday', '~> 0.9.2'

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ A collection of useful [Faraday][] middleware. [See the documentation][docs].
 Dependencies
 ------------
 
+Ruby >= 2.3.0
+
+#### As of version 0.16.0, faraday and faraday_middleware no longer support jruby or Rubinius
+
 Some dependent libraries are needed only when using specific middleware:
 
 | Middleware                  | Library        | Notes |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Dependencies
 
 Ruby >= 2.3.0
 
-#### As of version 0.16.0, faraday and faraday_middleware no longer support jruby or Rubinius
+#### As of v0.16.0, `faraday` and `faraday_middleware` no longer officially support JRuby or Rubinius.
 
 Some dependent libraries are needed only when using specific middleware:
 

--- a/faraday_middleware.gemspec
+++ b/faraday_middleware.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage = 'https://github.com/lostisland/faraday_middleware'
   spec.licenses = ['MIT']
 
-  spec.add_dependency 'faraday', ['>= 0.7.4', '< 1.0']
+  spec.add_dependency 'faraday', ['>= 0.16.0', '< 1.0']
 
   spec.files = `git ls-files -z lib LICENSE.md README.md`.split("\0")
 end

--- a/faraday_middleware.gemspec
+++ b/faraday_middleware.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage = 'https://github.com/lostisland/faraday_middleware'
   spec.licenses = ['MIT']
 
-  spec.add_dependency 'faraday', ['>= 0.16.0', '< 1.0']
+  spec.add_dependency 'faraday', '~> 0.16.0'
 
   spec.files = `git ls-files -z lib LICENSE.md README.md`.split("\0")
 end

--- a/faraday_middleware.gemspec
+++ b/faraday_middleware.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage = 'https://github.com/lostisland/faraday_middleware'
   spec.licenses = ['MIT']
 
-  spec.add_dependency 'faraday', '~> 0.16.0'
+  spec.add_dependency 'faraday', '~> 1.0'
 
   spec.files = `git ls-files -z lib LICENSE.md README.md`.split("\0")
 end

--- a/lib/faraday_middleware/backwards_compatibility.rb
+++ b/lib/faraday_middleware/backwards_compatibility.rb
@@ -15,4 +15,3 @@ module Faraday
     autoload :ParseYaml,    'faraday_middleware/response/parse_yaml'
   end
 end
-

--- a/lib/faraday_middleware/response/follow_redirects.rb
+++ b/lib/faraday_middleware/response/follow_redirects.rb
@@ -3,7 +3,7 @@ require 'set'
 
 module FaradayMiddleware
   # Public: Exception thrown when the maximum amount of requests is exceeded.
-  class RedirectLimitReached < Faraday::Error::ClientError
+  class RedirectLimitReached < Faraday::ClientError
     attr_reader :response
 
     def initialize(response)

--- a/lib/faraday_middleware/response/follow_redirects.rb
+++ b/lib/faraday_middleware/response/follow_redirects.rb
@@ -102,6 +102,8 @@ module FaradayMiddleware
       redirect_to_url = safe_escape(response['location'] || '')
       env[:url] += redirect_to_url
 
+      ENV_TO_CLEAR.each { |key| env.delete key }
+
       if convert_to_get?(response)
         env[:method] = :get
         env[:body] = nil
@@ -110,8 +112,6 @@ module FaradayMiddleware
       end
 
       clear_authorization_header(env, redirect_from_url, redirect_to_url)
-
-      ENV_TO_CLEAR.each {|key| env.delete key }
 
       env
     end

--- a/lib/faraday_middleware/response_middleware.rb
+++ b/lib/faraday_middleware/response_middleware.rb
@@ -38,8 +38,8 @@ module FaradayMiddleware
     def process_response(env)
       env[:raw_body] = env[:body] if preserve_raw?(env)
       env[:body] = parse(env[:body])
-    rescue Faraday::Error::ParsingError => err
-      raise Faraday::Error::ParsingError.new(err, env[:response])
+    rescue Faraday::ParsingError => e
+      raise Faraday::ParsingError.new(e, env[:response])
     end
 
     # Parse the response body.
@@ -49,9 +49,10 @@ module FaradayMiddleware
       if self.class.parser
         begin
           self.class.parser.call(body, @parser_options)
-        rescue StandardError, SyntaxError => err
-          raise err if err.is_a? SyntaxError and err.class.name != 'Psych::SyntaxError'
-          raise Faraday::Error::ParsingError, err
+        rescue StandardError, SyntaxError => e
+          raise e if e.is_a?(SyntaxError) && e.class.name != 'Psych::SyntaxError'
+
+          raise Faraday::ParsingError, e
         end
       else
         body

--- a/lib/faraday_middleware/version.rb
+++ b/lib/faraday_middleware/version.rb
@@ -1,3 +1,3 @@
 module FaradayMiddleware
-  VERSION = '0.13.1' unless defined?(FaradayMiddleware::VERSION)
+  VERSION = '0.16.0'.freeze unless defined?(FaradayMiddleware::VERSION)
 end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -60,8 +60,4 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
   config.disable_monkey_patching!
-
-  def jruby?
-    defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
-  end
 end

--- a/spec/unit/gzip_spec.rb
+++ b/spec/unit/gzip_spec.rb
@@ -2,7 +2,7 @@ require 'helper'
 require 'faraday_middleware/gzip'
 
 RSpec.describe FaradayMiddleware::Gzip, :type => :response do
-  require 'brotli' unless jruby?
+  require 'brotli'
 
   let(:middleware) {
     described_class.new(lambda { |env|
@@ -93,7 +93,7 @@ RSpec.describe FaradayMiddleware::Gzip, :type => :response do
       let(:headers) { {'Content-Encoding' => 'br', 'Content-Length' => body.length } }
 
       it_behaves_like 'compressed response'
-    end unless jruby?
+    end
 
     context 'empty response' do
       let(:body) { empty_body }

--- a/spec/unit/parse_dates_spec.rb
+++ b/spec/unit/parse_dates_spec.rb
@@ -3,13 +3,7 @@ require 'faraday_middleware/response/parse_dates'
 require 'json'
 
 RSpec.describe FaradayMiddleware::ParseDates, :type => :response do
-  let(:parsed){
-    if RUBY_VERSION > "1.9"
-      "2012-02-01 13:14:15 UTC"
-    else
-      "Wed Feb 01 13:14:15 UTC 2012"
-    end
-  }
+  let(:parsed){ "2012-02-01 13:14:15 UTC" }
 
   it "parses dates" do
     expect(process({"x" => "2012-02-01T13:14:15Z"}).body["x"].to_s).to eq(parsed)

--- a/spec/unit/parse_json_spec.rb
+++ b/spec/unit/parse_json_spec.rb
@@ -61,14 +61,14 @@ RSpec.describe FaradayMiddleware::ParseJson, :type => :response do
   end
 
   it "chokes on invalid json" do
-    expect{ process('{!') }.to raise_error(Faraday::Error::ParsingError)
+    expect{ process('{!') }.to raise_error(Faraday::ParsingError)
   end
 
   it "includes the response on the ParsingError instance" do
     begin
       process('{') { |env| env[:response] = Faraday::Response.new }
       fail 'Parsing should have failed.'
-    rescue Faraday::Error::ParsingError => err
+    rescue Faraday::ParsingError => err
       expect(err.response).to be_a(Faraday::Response)
     end
   end

--- a/spec/unit/parse_marshal_spec.rb
+++ b/spec/unit/parse_marshal_spec.rb
@@ -11,6 +11,6 @@ RSpec.describe FaradayMiddleware::ParseMarshal, :type => :response do
   end
 
   it "chokes on invalid content" do
-    expect{ process('abc') }.to raise_error(Faraday::Error::ParsingError)
+    expect{ process('abc') }.to raise_error(Faraday::ParsingError)
   end
 end

--- a/spec/unit/parse_xml_spec.rb
+++ b/spec/unit/parse_xml_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe FaradayMiddleware::ParseXml, :type => :response do
 
   it "chokes on invalid xml" do
     ['{!', '"a"', 'true', 'null', '1'].each do |data|
-      expect{ process(data) }.to raise_error(Faraday::Error::ParsingError)
+      expect{ process(data) }.to raise_error(Faraday::ParsingError)
     end
   end
 

--- a/spec/unit/parse_yaml_spec.rb
+++ b/spec/unit/parse_yaml_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe FaradayMiddleware::ParseYaml, :type => :response do
   end
 
   it "chokes on invalid yaml" do
-    expect{ process('{!') }.to raise_error(Faraday::Error::ParsingError)
+    expect{ process('{!') }.to raise_error(Faraday::ParsingError)
   end
 
   context "SafeYAML options" do


### PR DESCRIPTION
Faraday 0.16.0 compatibility, drops support for rubies < 2.3.0, jruby and rubinius