### PR TITLE
CI: Add 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.4
   - 2.5.0
   - 2.6.3
+  - 2.7
 matrix:
   fast_finish: true
 deploy:


### PR DESCRIPTION
See #200 

This PR adds Ruby 2.7 to the build matrix.

With it in place, we can mine the output for 2.7 warnings, and quash them.