### PR TITLE
chore: RuboCop lint Layout/EmptyLineAfterGuardClause

### DIFF
--- a/lib/faraday_middleware/rack_compatible.rb
+++ b/lib/faraday_middleware/rack_compatible.rb
@@ -59,6 +59,7 @@ module FaradayMiddleware
 
       rack_env.each do |name, value|
         next unless String === name && String === value
+
         if NonPrefixedHeaders.include? name or name.index('HTTP_') == 0
           name = name.sub(/^HTTP_/, '').downcase.tr('_', '-')
           headers[name] = value

--- a/lib/faraday_middleware/response/chunked.rb
+++ b/lib/faraday_middleware/response/chunked.rb
@@ -11,6 +11,7 @@ module FaradayMiddleware
         chunk_len, raw_body = raw_body.split("\r\n", 2)
         chunk_len = chunk_len.split(';',2).first.hex
         break if chunk_len == 0
+
         decoded_body << raw_body[0, chunk_len]
         # The 2 is to strip the extra CRLF at the end of the chunk
         raw_body = raw_body[chunk_len + 2, raw_body.length - chunk_len - 2]

--- a/lib/faraday_middleware/response/follow_redirects.rb
+++ b/lib/faraday_middleware/response/follow_redirects.rb
@@ -89,6 +89,7 @@ module FaradayMiddleware
       response.on_complete do |response_env|
         if follow_redirect?(response_env, response)
           raise RedirectLimitReached, response if follows.zero?
+
           new_request_env = update_env(response_env.dup, request_body, response)
           callback.call(response_env, new_request_env) if callback
           response = perform_with_redirection(new_request_env, follows - 1)

--- a/lib/faraday_middleware/response_middleware.rb
+++ b/lib/faraday_middleware/response_middleware.rb
@@ -90,6 +90,7 @@ module FaradayMiddleware
 
     def each
       return to_enum(:each) unless block_given?
+
       super
       yield :preserve_raw, preserve_raw
     end

--- a/spec/unit/caching_spec.rb
+++ b/spec/unit/caching_spec.rb
@@ -204,6 +204,7 @@ RSpec.describe FaradayMiddleware::RackCompatible, 'caching' do
       if error_stream.respond_to?(:string) && error_stream.string.include?('error')
         raise %(unexpected error in 'rack.errors': %p) % error_stream.string
       end
+
       response
     end
   end

--- a/spec/unit/follow_redirects_spec.rb
+++ b/spec/unit/follow_redirects_spec.rb
@@ -354,6 +354,7 @@ RSpec.describe FaradayMiddleware::FollowRedirects do
       if defined?(Faraday::Env) && !env.is_a?(Faraday::Env)
         raise "expected Faraday::Env, got #{env.class}"
       end
+
       app.call(env)
     end
   end

--- a/spec/unit/oauth_spec.rb
+++ b/spec/unit/oauth_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe FaradayMiddleware::OAuth do
   def auth_values(env)
     if auth = auth_header(env)
       raise "invalid header: #{auth.inspect}" unless auth.sub!('OAuth ', '')
+
       Hash[*auth.split(/, |=/)]
     end
   end


### PR DESCRIPTION
What the title says, see https://github.com/lostisland/faraday_middleware/issues/204

No meat on this, just rubocop warning fixes