### PR TITLE
 chore: RuboCop lint Layout/SpaceAfterComma

### DIFF
--- a/lib/faraday_middleware/request/oauth.rb
+++ b/lib/faraday_middleware/request/oauth.rb
@@ -78,7 +78,7 @@ module FaradayMiddleware
 
     def signature_params(params)
       params.empty? ? params :
-        params.reject {|k,v| v.respond_to?(:content_type) }
+        params.reject {|k, v| v.respond_to?(:content_type) }
     end
   end
 end

--- a/lib/faraday_middleware/response/chunked.rb
+++ b/lib/faraday_middleware/response/chunked.rb
@@ -9,7 +9,7 @@ module FaradayMiddleware
       decoded_body = []
       until raw_body.empty?
         chunk_len, raw_body = raw_body.split("\r\n", 2)
-        chunk_len = chunk_len.split(';',2).first.hex
+        chunk_len = chunk_len.split(';', 2).first.hex
         break if chunk_len == 0
         decoded_body << raw_body[0, chunk_len]
         # The 2 is to strip the extra CRLF at the end of the chunk

--- a/spec/unit/parse_dates_spec.rb
+++ b/spec/unit/parse_dates_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe FaradayMiddleware::ParseDates, :type => :response do
   end
 
   it 'leaves arrays with ids alone' do
-    expect(process({'x' => [1,2,3]}).body).to eq({'x' => [1,2,3]})
+    expect(process({'x' => [1, 2, 3]}).body).to eq({'x' => [1, 2, 3]})
   end
 
   it 'does not parse date-like things' do


### PR DESCRIPTION
No meat on this, just rubocop warning fix for spaces after commas 

See https://github.com/lostisland/faraday_middleware/issues/200