### PR TITLE
gemspec: Support Ruby 2.3+

### DIFF
--- a/faraday_middleware.gemspec
+++ b/faraday_middleware.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |spec|
   spec.homepage = 'https://github.com/lostisland/faraday_middleware'
   spec.licenses = ['MIT']
 
+  spec.required_ruby_version = '>= 2.3'
+
   spec.add_dependency 'faraday', '~> 1.0'
 
   spec.files = `git ls-files -z lib LICENSE.md README.md`.split("\0")


### PR DESCRIPTION
This is the same as Faraday 1.0.

Before, it was not marked as restricted.