### PR TITLE
chore: Exclude 1 instance of Naming/PredicateName cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,6 +18,10 @@ Layout/LineLength:
     - spec/**/*.rb
     - examples/**/*.rb
 
+Naming/PredicateName:
+  Exclude:
+    - 'lib/faraday_middleware/request/encode_json.rb'
+
 Style/DoubleNegation:
   Enabled: false
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -21,17 +21,6 @@ Metrics/AbcSize:
 Metrics/MethodLength:
   Max: 17
 
-# Offense count: 1
-# Configuration parameters: NamePrefix, ForbiddenPrefixes, AllowedMethods, MethodDefinitionMacros.
-# NamePrefix: is_, has_, have_
-# ForbiddenPrefixes: is_, has_, have_
-# AllowedMethods: is_a?
-# MethodDefinitionMacros: define_method, define_singleton_method
-Naming/PredicateName:
-  Exclude:
-    - 'spec/**/*'
-    - 'lib/faraday_middleware/request/encode_json.rb'
-
 # Offense count: 2
 Security/MarshalLoad:
   Exclude:


### PR DESCRIPTION
Closes #231 

See #204 

>  Perhaps we could take this into the known-and-ignored in the .rubocop.yml file - as opposed into the .rubocop_todo.yml file.