### PR TITLE
chore: RuboCop-allow middleware for Marshal to Marshal.load

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,11 @@ Naming/PredicateName:
   Exclude:
     - 'lib/faraday_middleware/request/encode_json.rb'
 
+Security/MarshalLoad:
+  Exclude:
+    - 'lib/faraday_middleware/response/parse_marshal.rb'
+    - 'spec/unit/caching_spec.rb'
+
 Style/DoubleNegation:
   Enabled: false
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -15,12 +15,6 @@ Metrics/AbcSize:
 Metrics/MethodLength:
   Max: 17
 
-# Offense count: 2
-Security/MarshalLoad:
-  Exclude:
-    - 'lib/faraday_middleware/response/parse_marshal.rb'
-    - 'spec/unit/caching_spec.rb'
-
 # Offense count: 1
 # Configuration parameters: EnforcedStyle.
 # SupportedStyles: inline, group


### PR DESCRIPTION
This PR promotes one TODO in RuboCop to an allowed thing:

- The middleware for Marshal.load MAY Marshal.load