### PR TITLE
chore: Promote cop Style/AccessModifierDeclarations to rule, for 1 ex…

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,10 @@ Security/MarshalLoad:
     - 'lib/faraday_middleware/response/parse_marshal.rb'
     - 'spec/unit/caching_spec.rb'
 
+Style/AccessModifierDeclarations:
+  Exclude:
+    - 'spec/unit/follow_redirects_spec.rb'
+
 Style/DoubleNegation:
   Enabled: false
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -15,13 +15,6 @@ Metrics/AbcSize:
 Metrics/MethodLength:
   Max: 17
 
-# Offense count: 1
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: inline, group
-Style/AccessModifierDeclarations:
-  Exclude:
-    - 'spec/unit/follow_redirects_spec.rb'
-
 # Offense count: 3
 Style/CaseEquality:
   Exclude:


### PR DESCRIPTION
The cop Style/AccessModifierDeclarations is used in the project, but for 1 specific, tricky spec thing, we bend this rule.

See #204 