### PR TITLE
Avoid String#chr

### DIFF
--- a/lib/faraday_middleware/response/parse_json.rb
+++ b/lib/faraday_middleware/response/parse_json.rb
@@ -41,7 +41,6 @@ module FaradayMiddleware
         char = body[idx += 1]
         while char && WHITESPACE.include?(char)
           char = body[idx += 1]
-          char = char.chr if char
         end
         char
       end

--- a/lib/faraday_middleware/response/parse_json.rb
+++ b/lib/faraday_middleware/response/parse_json.rb
@@ -39,9 +39,7 @@ module FaradayMiddleware
       def first_char(body)
         idx = -1
         char = body[idx += 1]
-        while char && WHITESPACE.include?(char)
-          char = body[idx += 1]
-        end
+        char = body[idx += 1] while char && WHITESPACE.include?(char)
         char
       end
     end


### PR DESCRIPTION
Supporting Ruby 1.8 has been dropped. #216

In Ruby 1.9+, string[nth] returns String.
No need to call String#chr.

---

FYI:

`String#chr` is only for compatibility with Ruby 1.8.

* In Ruby 1.8
  - `string[nth]` returns `Integer|nil`
  - Use `Integer#chr` for gets character
* In Ruby 1.9
  - `string[nth]` returns `String|nil`
  - `String#chr` has been implemented to work with the same code as Ruby 1.8

```ruby
# This code can get char in both 1.8 and 1.9
'foo'[0].chr
# => "f"
```