### PR TITLE
Psych is default YAML Engine since Ruby 1.9.3

### DIFF
--- a/lib/faraday_middleware/response/parse_yaml.rb
+++ b/lib/faraday_middleware/response/parse_yaml.rb
@@ -30,11 +30,7 @@ module FaradayMiddleware
     dependency 'safe_yaml/load'
 
     define_parser do |body, parser_options|
-      if SafeYAML::YAML_ENGINE == 'psych'
-        SafeYAML.load(body, nil, parser_options || {})
-      else
-        SafeYAML.load(body, parser_options || {})
-      end
+      SafeYAML.load(body, nil, parser_options || {})
     end
   end
 end


### PR DESCRIPTION
And Syck is removed since Ruby 2.0.0.

---

I think, SafeYAML is also deprecated in Ruby 2.3+.
Use `YAML.safe_load` instead of `SafeYAML.load`.

```ruby
class ParseYaml < ResponseMiddleware
  define_parser do |body, parser_options|
    YAML.safe_load(body, **(parser_options || {}))
  end
end
```

But there are two problems.

#### SafeYAML and YAML's option is not compatible.

This makes a breaking change.

* SafeYAML
  - `:deserialize_symbols`
  - `:whitelisted_tags`
  - `:custom_initializers`
  - `:raise_on_unknown_tag`
* YAML
  - `:permitted_classes`
  - `:permitted_symbols`
  - `:aliases`
  - `:filename`
  - `:fallback`
  - `:symbolize_names`

#### `YAML.safe_load` option is not compatible in Ruby 2.3-2.7

Supporting all of this is a bit too complicated.

2.3, 2.4:

```ruby
def self.safe_load yaml, whitelist_classes = [], whitelist_symbols = [], aliases = false, filename = nil
```

2.5: `symbolize_names` is added as kwargs

```ruby
def self.safe_load yaml, whitelist_classes = [], whitelist_symbols = [], aliases = false, filename = nil, symbolize_names: false
```

2.6+: all arguments are now kwargs

```ruby
def self.safe_load yaml, permitted_classes: [], permitted_symbols: [], aliases: false, filename: nil, fallback: nil, symbolize_names: false
```