### PR TITLE
Use default SimpleCov.formatter

### DIFF
--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -2,16 +2,6 @@
 
 if ENV['COVERAGE']
   require 'simplecov'
-
-  SimpleCov.formatter = Class.new do
-    def format(result)
-      SimpleCov::Formatter::HTMLFormatter.new.format(result) unless ENV['CI']
-      File.open('coverage/covered_percent', 'w') do |f|
-        f.printf('%<percentage>.2f', percentage: result.source_files.covered_percent)
-      end
-    end
-  end
-
   SimpleCov.start do
     # add_filter 'faraday_middleware.rb'
     add_filter 'backwards_compatibility.rb'


### PR DESCRIPTION
`coverage/covered_percent` is for Cane gem
and Cane is removed at #202.
`cc-test-reporter` uses `coverage/.resultset.json`.

### Keep stopping HTML output in CI?

It is ECO, but not the default behavior of SimpleCov.
HTMLFormatter is SimpleCov's default formatter. (even in CI)`