### PR TITLE
Faraday::Utils.(build|parse)_nested_query is defined

### DIFF
--- a/lib/faraday_middleware/request/oauth.rb
+++ b/lib/faraday_middleware/request/oauth.rb
@@ -30,13 +30,7 @@ module FaradayMiddleware
     TYPE_URLENCODED = 'application/x-www-form-urlencoded'
 
     extend Forwardable
-    parser_method = :parse_nested_query
-    parser_module = if ::Faraday::Utils.respond_to?(parser_method)
-                      'Faraday::Utils'
-                    else
-                      'Rack::Utils'
-                    end
-    def_delegator parser_module, parser_method
+    def_delegator :'Faraday::Utils', :parse_nested_query
 
     def initialize(app, options)
       super(app)

--- a/spec/unit/oauth_spec.rb
+++ b/spec/unit/oauth_spec.rb
@@ -118,9 +118,7 @@ RSpec.describe FaradayMiddleware::OAuth do
     let(:type_form) { { 'Content-Type' => 'application/x-www-form-urlencoded' } }
 
     extend Forwardable
-    query_method = :build_nested_query
-    query_module = ::Faraday::Utils.respond_to?(query_method) ? 'Faraday::Utils' : 'Rack::Utils'
-    def_delegator query_module, query_method
+    def_delegator :'Faraday::Utils', :build_nested_query
 
     it 'does not include the body for JSON' do
       auth_header_with    = auth_header(perform({}, type_json, '{"foo":"bar"}'))


### PR DESCRIPTION
Supporting Faraday v0.7 has been dropped.

`Faraday::Utils.build_nested_query` and `parse_nested_query`
are implemented in Faraday v0.8.0.
https://github.com/lostisland/faraday/commit/0d517cda5f