### PR TITLE
Set version to 1.0.0.rc1

### DIFF
--- a/lib/faraday_middleware/version.rb
+++ b/lib/faraday_middleware/version.rb
@@ -2,5 +2,5 @@
 
 # Main FaradayMiddleware module.
 module FaradayMiddleware
-  VERSION = '1.0.0' unless defined?(FaradayMiddleware::VERSION)
+  VERSION = '1.0.0.rc1' unless defined?(FaradayMiddleware::VERSION)
 end


### PR DESCRIPTION
This PR sets the version number to `1.0.0.rc1` in order to be able to release a Release Candidate.

See #200 - this will make it possible to try out the "1.0" release before 1.0.0 is released.