### PR TITLE
Split error class to its own file

### DIFF
--- a/lib/faraday_middleware.rb
+++ b/lib/faraday_middleware.rb
@@ -18,6 +18,7 @@ module FaradayMiddleware
   autoload :Caching,         'faraday_middleware/response/caching'
   autoload :Chunked,         'faraday_middleware/response/chunked'
   autoload :RackCompatible,  'faraday_middleware/rack_compatible'
+  autoload :RedirectLimitReached, 'faraday_middleware/redirect_limit_reached'
   autoload :FollowRedirects, 'faraday_middleware/response/follow_redirects'
   autoload :Instrumentation, 'faraday_middleware/instrumentation'
   autoload :Gzip, 'faraday_middleware/gzip'

--- a/lib/faraday_middleware/redirect_limit_reached.rb
+++ b/lib/faraday_middleware/redirect_limit_reached.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'faraday'
+
+module FaradayMiddleware
+  # Exception thrown when the maximum amount of requests is
+  # exceeded.
+  class RedirectLimitReached < Faraday::ClientError
+    attr_reader :response
+
+    def initialize(response)
+      super "too many redirects; last one to: #{response['location']}"
+      @response = response
+    end
+  end
+end

--- a/lib/faraday_middleware/response/follow_redirects.rb
+++ b/lib/faraday_middleware/response/follow_redirects.rb
@@ -1,19 +1,10 @@
 # frozen_string_literal: true
 
 require 'faraday'
+require 'faraday_middleware/redirect_limit_reached'
 require 'set'
 
 module FaradayMiddleware
-  # Public: Exception thrown when the maximum amount of requests is exceeded.
-  class RedirectLimitReached < Faraday::ClientError
-    attr_reader :response
-
-    def initialize(response)
-      super "too many redirects; last one to: #{response['location']}"
-      @response = response
-    end
-  end
-
   # Public: Follow HTTP 301, 302, 303, 307, and 308 redirects.
   #
   # For HTTP 301, 302, and 303, the original GET, POST, PUT, DELETE, or PATCH

--- a/lib/faraday_middleware/response/follow_redirects.rb
+++ b/lib/faraday_middleware/response/follow_redirects.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'faraday'
-require 'faraday_middleware/redirect_limit_reached'
 require 'set'
 
 module FaradayMiddleware

--- a/spec/unit/follow_redirects_spec.rb
+++ b/spec/unit/follow_redirects_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'helper'
+require 'faraday_middleware'
 require 'faraday_middleware/response/follow_redirects'
 require 'faraday'
 


### PR DESCRIPTION
This PR moves the one specific error we define, to its expected file location.

To get autoloading to work:

- mention the class name in the main file (lib/faraday_middleware.rb)
- separate out to its own file
- ensure that a spec which was relying on that to be loaded had the main file loaded

See #198 