### PR TITLE
Import wiki pages as Markdown

### DIFF
--- a/docs/caching_responses.md
+++ b/docs/caching_responses.md
@@ -1,0 +1,50 @@
+# Caching responses
+
+## Simple response body caching
+
+FaradayMiddleware::Caching can be configured with a cache store that
+responds to `read`, `write` and `fetch`, such as one of
+ActiveSupport::Cache stores.
+
+Example use:
+
+```rb
+cache_dir = File.join(ENV['TMPDIR'] || '/tmp', 'cache')
+
+conn.response :caching, :ignore_params => %w[access_token] do  
+  ActiveSupport::Cache::FileStore.new cache_dir, :namespace => 'my_namespace',
+    :expires_in => 3600  # one hour
+end
+```
+
+In the above example, the return value of the block represents the cache
+store that the middleware will use. It's configured to cache each
+GET response for 1 hour.
+
+## Advanced HTTP caching
+
+FaradayMiddleware::RackCompatible can be used to mount [rack-cache][] to
+the middleware stack in order to perform caching per HTTP spec.
+
+```rb
+conn.use FaradayMiddleware::RackCompatible, Rack::Cache::Context,
+  :metastore   => "file:#{cache_dir}/rack/meta",
+  :entitystore => "file:#{cache_dir}/rack/body",
+  :ignore_headers => %w[Set-Cookie X-Content-Digest]
+```
+
+In the above example, the stack is configured to cache successful
+responses to disk according to HTTP freshness/expiration information,
+and subsequent requests will be validated using information in
+Last-Modified/ETag headers.
+
+The `:ignore_headers` option is important to enable caching even if the server
+where the data is coming from uses Rack::Cache, too. This is due to
+[rack-cache issue #59][bug].
+
+**Using RackCompatible middleware to mount Rack::Cache is kind of a hack**.
+Consider using [faraday-http-cache] instead.
+
+  [rack-cache]: http://rtomayko.github.com/rack-cache/
+  [bug]: https://github.com/rtomayko/rack-cache/issues/59
+  [faraday-http-cache]: https://github.com/plataformatec/faraday-http-cache

--- a/docs/gzip.md
+++ b/docs/gzip.md
@@ -1,9 +1,10 @@
 # Gzip Compression
 
-FaradayMiddleware::Gzip to automatically decompress response bodies. If the "Accept-Encoding" header wasn't set in the request, this sets it to "gzip,deflate" and appropriately handles the compressed response from the server. This resembles what Ruby 1.9+ does internally in Net::HTTP#get.
+Use `FaradayMiddleware::Gzip` to automatically decompress response bodies. If the "Accept-Encoding" header wasn't set in the request, this sets it to "gzip,deflate" and appropriately handles the compressed response from the server. This resembles what Ruby does internally in Net::HTTP#get.
 
 This middleware is NOT necessary when these adapters are used:
-- net_http on Ruby 1.9+
-- net_http_persistent on Ruby 2.0+
-- em_http
+
+- `net_http`
+- `net_http_persistent`
+- `em_http`
 

--- a/docs/gzip.md
+++ b/docs/gzip.md
@@ -1,0 +1,9 @@
+# Gzip Compression
+
+FaradayMiddleware::Gzip to automatically decompress response bodies. If the "Accept-Encoding" header wasn't set in the request, this sets it to "gzip,deflate" and appropriately handles the compressed response from the server. This resembles what Ruby 1.9+ does internally in Net::HTTP#get.
+
+This middleware is NOT necessary when these adapters are used:
+- net_http on Ruby 1.9+
+- net_http_persistent on Ruby 2.0+
+- em_http
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,55 @@
+# faraday_middleware documentation
+
+This is a collection of middleware for the [Faraday][] project.
+
+Example use:
+
+```rb
+require 'faraday_middleware'
+
+connection = Faraday.new 'http://example.com/api' do |conn|
+  conn.request :oauth2, 'TOKEN'
+  conn.request :json
+
+  conn.response :xml,  :content_type => /\bxml$/
+  conn.response :json, :content_type => /\bjson$/
+
+  conn.use :instrumentation
+  conn.adapter Faraday.default_adapter
+end
+```
+
+**Important:** same as with Rack middleware, the order of middleware on
+a Faraday stack is significant. General guidelines:
+
+1. put request middleware first, in order of importance;
+2. put response middleware second, in the reverse order of importance;
+3. ensure that the adapter is always last.
+
+## Request middleware:
+
+* FaradayMiddleware::EncodeJson
+* FaradayMiddleware::OAuth
+* FaradayMiddleware::OAuth2
+* [[FaradayMiddleware::MethodOverride|method override]]
+
+## Response middleware:
+
+* [[Parsing responses]]:
+  * FaradayMiddleware::ParseJson
+  * FaradayMiddleware::ParseXml
+  * FaradayMiddleware::ParseYaml
+  * FaradayMiddleware::ParseMarshal
+* [[FaradayMiddleware::Caching|Caching]]
+* FaradayMiddleware::FollowRedirects
+* FaradayMiddleware::Mashify
+* FaradayMiddleware::Rashify
+
+## Other middleware:
+
+* [[FaradayMiddleware::Instrumentation|Instrumentation]]
+* [[FaradayMiddleware::RackCompatible|Caching]]
+* [[FaradayMiddleware::Gzip|Gzip Compression]]
+
+[faraday]: https://github.com/lostisland/faraday#readme
+

--- a/docs/instrumentation.md
+++ b/docs/instrumentation.md
@@ -1,0 +1,23 @@
+# Instrumenting requests with Active Support
+
+FaradayMiddleware::Instrumentation uses Active Support to instrument
+requests. It records information about each request and time spent
+performing it.
+
+```rb
+conn.use :instrumentation
+```
+
+The default key under which all requests are instrumented is
+"request.faraday". You can subscribe to these events and log them
+accordingly:
+
+```rb
+ActiveSupport::Notifications.subscribe('request.faraday') do |name, start_time, end_time, _, env|
+  url = env[:url]
+  http_method = env[:method].to_s.upcase
+  duration = end_time - start_time
+  $stderr.puts '[%s] %s %s (%.3f s)' % [url.host, http_method, url.request_uri, duration]
+end
+```
+

--- a/docs/method_override.md
+++ b/docs/method_override.md
@@ -1,10 +1,10 @@
 # Method override
 
-Writes the original HTTP method to "X-Http-Method-Override" header and changes the request method to POST.
+Changes the request method to POST and writes the original HTTP method to the "X-Http-Method-Override" header.
 
-This can be used to work around technical issues with making non-POST requests, e.g. faulty HTTP client or server router.
+This can be used to work around technical issues with making non-POST requests, e.g. a faulty HTTP client or server router.
 
-This header is recognized in Rack apps by default, courtesy of the [Rack::MethodOverride](http://rack.rubyforge.org/doc/classes/Rack/MethodOverride.html) module.
+This header is recognized in Rack apps by default, courtesy of the [Rack::MethodOverride](https://www.rubydoc.info/github/rack/rack/Rack/MethodOverride) module.
 
 ```rb
 connection = Faraday.new 'http://example.com/api' do |conn|

--- a/docs/method_override.md
+++ b/docs/method_override.md
@@ -1,0 +1,20 @@
+# Method override
+
+Writes the original HTTP method to "X-Http-Method-Override" header and changes the request method to POST.
+
+This can be used to work around technical issues with making non-POST requests, e.g. faulty HTTP client or server router.
+
+This header is recognized in Rack apps by default, courtesy of the [Rack::MethodOverride](http://rack.rubyforge.org/doc/classes/Rack/MethodOverride.html) module.
+
+```rb
+connection = Faraday.new 'http://example.com/api' do |conn|
+  # rewrite all non-GET/POST requests:
+  conn.request :method_override
+
+  # rewrite just PATCH and OPTIONS requests:
+  conn.request :method_override, rewrite: [:patch, :options]
+end
+
+connection.patch('users/12', payload)
+#=> sends the request as POST, but with "X-Http-Method-Override: PATCH" header
+```

--- a/docs/oauth.md
+++ b/docs/oauth.md
@@ -1,0 +1,32 @@
+# OAuth Middleware for token authentication
+
+Available middleware:
+
+* FaradayMiddleware::OAuth
+* FaradayMiddleware::OAuth2
+
+Example use (OAuth 2):
+
+```rb
+connection = Faraday.new('http://example.com/api') do |conn|
+  conn.request :oauth2, 'token'
+  conn.adapter Faraday.default_adapter
+end
+```
+
+This will cause the 'token' to be inserted in both the query params (as `access_token`) and headers (as `Token token=<token_value>`).
+
+As of FaradayMiddleware 0.11, you can specify the `token_type` option as `:bearer`:
+
+```rb
+connection = Faraday.new('http://example.com/api') do |conn|
+  conn.request :oauth2, 'token', token_type: :bearer
+  conn.adapter Faraday.default_adapter
+end
+```
+
+This will cause the token to be inserted ONLY as a header (as `Bearer <token_value>`), which is more standard-compliant.
+
+## DEPRECATION WARNING
+
+Inserting the token as a parameter is now considered a security issue, therefore the next major release of Faraday will only add tokens on headers.


### PR DESCRIPTION
This PR imports all the wiki pages as Markdown documents into the repository.

Excluded: "Changes in 0.8".

See #250. 

