### PR TITLE
Use wrapped exception in Faraday::ParsingError to improve legibility of the error

### DIFF
--- a/lib/faraday_middleware/response_middleware.rb
+++ b/lib/faraday_middleware/response_middleware.rb
@@ -44,7 +44,7 @@ module FaradayMiddleware
       env[:raw_body] = env[:body] if preserve_raw?(env)
       env[:body] = parse(env[:body])
     rescue Faraday::ParsingError => e
-      raise Faraday::ParsingError.new(e, env[:response])
+      raise Faraday::ParsingError.new(e.wrapped_exception, env[:response])
     end
 
     # Parse the response body.


### PR DESCRIPTION
This is from that existing issue that's open, #160.

Fixes #160