### PR TITLE
update webmock to min 2.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ group :test do
   gem 'rspec', '>= 3'
   gem 'rubocop-performance', '~> 1.0'
   gem 'simplecov', '~> 0.12.0'
-  gem 'webmock', '< 2'
+  gem 'webmock', '~> 2.3'
 end
 
 gemspec


### PR DESCRIPTION
Fixes the following: 
```
FaradayMiddleware::FollowRedirects redirects on 308
     Failure/Error: response = @app.call(env)

     NoMethodError:
       undefined method `close' for #<StubSocket:0x000055fda3b90950>
       Did you mean?  closed?
                      clone
     # /home/runner/.rvm/gems/ruby-2.5.8/gems/webmock-1.24.6/lib/webmock/http_lib_adapters/net_http.rb:125:in `start_without_connect'
     # /home/runner/.rvm/gems/ruby-2.5.8/gems/webmock-1.24.6/lib/webmock/http_lib_adapters/net_http.rb:150:in `start'
     # /home/runner/.rvm/gems/ruby-2.5.8/gems/faraday-1.0.1/lib/faraday/adapter/net_http.rb:144:in `request_via_get_method'
     # /home/runner/.rvm/gems/ruby-2.5.8/gems/faraday-1.0.1/lib/faraday/adapter/net_http.rb:135:in `request_with_wrapped_block'
     # /home/runner/.rvm/gems/ruby-2.5.8/gems/faraday-1.0.1/lib/faraday/adapter/net_http.rb:128:in `perform_request'
     # /home/runner/.rvm/gems/ruby-2.5.8/gems/faraday-1.0.1/lib/faraday/adapter/net_http.rb:70:in `block in call'
     # /home/runner/.rvm/gems/ruby-2.5.8/gems/faraday-1.0.1/lib/faraday/adapter.rb:60:in `connection'
     # /home/runner/.rvm/gems/ruby-2.5.8/gems/faraday-1.0.1/lib/faraday/adapter/net_http.rb:68:in `call'
     # ./lib/faraday_middleware/response/follow_redirects.rb:79:in `perform_with_redirection'
     # ./lib/faraday_middleware/response/follow_redirects.rb:67:in `call'
```
note, this issue's only on faraday 1.0.1

I'm happy to do anything testing-wise this requires if you all want it in. 

see https://github.com/bblimke/webmock/issues/683