### PR TITLE
bump rubocop-performance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'simple_oauth', '>= 0.1', '< 0.3'
 group :test do
   gem 'addressable', '< 2.4'
   gem 'rspec', '>= 3'
-  gem 'rubocop-performance', '~> 1.0'
+  gem 'rubocop-performance', '~> 1.5.2'
   gem 'simplecov', '~> 0.12.0'
   gem 'webmock', '~> 2.3'
 end


### PR DESCRIPTION
the cops in issue 256 need a minimum rubocop 0.80 so maybe it makes sense to do this first, I dunno. 