### PR TITLE
Configure RuboCop for CodeClimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,7 @@
+plugins:
+  rubocop:
+    enabled: true
+    config:
+      file: .rubocop_codeclimate.yml
+    channel: rubocop-0-81
+

--- a/.rubocop_codeclimate.yml
+++ b/.rubocop_codeclimate.yml
@@ -1,0 +1,2 @@
+inherit_from: .rubocop.yml
+require: []


### PR DESCRIPTION
  - Add CodeClimate YAML configuration file
  - Point out 0.81 "channel" for most-modern cops
  - Add a RuboCop CodeClimate-specific YAML configuration file: Disable the `require` YAML setting, which pulls in unsupported-in-CodeClimate Plugins we also use

Fixes #260 