### PR TITLE
Drop CodeClimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,7 +1,0 @@
-plugins:
-  rubocop:
-    enabled: true
-    config:
-      file: .rubocop_codeclimate.yml
-    channel: rubocop-0-81
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
 env:
   GIT_COMMIT_SHA: ${{ github.sha }}
   GIT_BRANCH: ${{ github.ref }}
-  CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
 
 jobs:
   linting:
@@ -65,19 +64,7 @@ jobs:
         gem install bundler -v '<2'
         bundle install --jobs 4 --retry 3
 
-    - name: Setup Code Climate
-      if: matrix.ruby == '2.6'
-      run: |
-        curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-        chmod +x ./cc-test-reporter
-        ./cc-test-reporter before-build
-
     - name: Test
       run: |
         source $HOME/.rvm/scripts/rvm
         bundle exec rake
-
-    - name: Run Code Climate Test Reporter
-      if: success() && matrix.ruby == '2.6'
-      run: ./cc-test-reporter after-build --coverage-input-type simplecov --exit-code $?
-      continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@ Faraday Middleware
 ==================
 [![Gem Version](https://badge.fury.io/rb/faraday_middleware.svg)](https://rubygems.org/gems/faraday_middleware)
 ![GitHub Actions CI](https://github.com/lostisland/faraday_middleware/workflows/CI/badge.svg)
-[![Maintainability](https://api.codeclimate.com/v1/badges/a971ee5025b269c39d93/maintainability)](https://codeclimate.com/github/lostisland/faraday_middleware/maintainability)
 
 A collection of useful [Faraday][] middleware. [See the documentation][docs].
 


### PR DESCRIPTION
This PR removes CodeClimate.

The badge has been showing grey for a while, and nobody has acted on that. The reason why the badge was grey: CC is unable to run a configured RuboCop, with a single plugin.

If we need to do spot-checks for metrics, we can use rubycritic in a focused sitting.

TODO:

- [x] remove the Secret in Settings