### PR TITLE
Update default branch name to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
 
   push:
     branches:
-      - master
+      - main
 
 env:
   GIT_COMMIT_SHA: ${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ Some dependent libraries are needed only when using specific middleware:
 
 | Middleware                  | Library        | Notes |
 | --------------------------- | -------------- | ----- |
-| [FaradayMiddleware::Instrumentation](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/instrumentation.rb) | [`activesupport`](https://rubygems.org/gems/activesupport) |       |
-| [FaradayMiddleware::OAuth](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/request/oauth.rb)    | [`simple_oauth`](https://rubygems.org/gems/simple_oauth) |       |
-| [FaradayMiddleware::ParseXml](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/response/parse_xml.rb) | [`multi_xml`](https://rubygems.org/gems/multi_xml)    |       |
-| [FaradayMiddleware::ParseYaml](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/response/parse_yaml.rb)  | [`safe_yaml`](https://rubygems.org/gems/safe_yaml)     | Not backwards compatible with versions of this middleware prior to `faraday_middleware` v0.12. See code comments for alternatives. |
-| [FaradayMiddleware::Mashify](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/response/mashify.rb)  | [`hashie`](https://rubygems.org/gems/hashie)       |       |
-| [FaradayMiddleware::Rashify](https://github.com/lostisland/faraday_middleware/blob/master/lib/faraday_middleware/response/rashify.rb)  | [`rash_alt`](https://rubygems.org/gems/rash_alt)     | Make sure to uninstall original `rash` gem to avoid conflict. |
+| [FaradayMiddleware::Instrumentation](https://github.com/lostisland/faraday_middleware/blob/main/lib/faraday_middleware/instrumentation.rb) | [`activesupport`](https://rubygems.org/gems/activesupport) |       |
+| [FaradayMiddleware::OAuth](https://github.com/lostisland/faraday_middleware/blob/main/lib/faraday_middleware/request/oauth.rb)    | [`simple_oauth`](https://rubygems.org/gems/simple_oauth) |       |
+| [FaradayMiddleware::ParseXml](https://github.com/lostisland/faraday_middleware/blob/main/lib/faraday_middleware/response/parse_xml.rb) | [`multi_xml`](https://rubygems.org/gems/multi_xml)    |       |
+| [FaradayMiddleware::ParseYaml](https://github.com/lostisland/faraday_middleware/blob/main/lib/faraday_middleware/response/parse_yaml.rb)  | [`safe_yaml`](https://rubygems.org/gems/safe_yaml)     | Not backwards compatible with versions of this middleware prior to `faraday_middleware` v0.12. See code comments for alternatives. |
+| [FaradayMiddleware::Mashify](https://github.com/lostisland/faraday_middleware/blob/main/lib/faraday_middleware/response/mashify.rb)  | [`hashie`](https://rubygems.org/gems/hashie)       |       |
+| [FaradayMiddleware::Rashify](https://github.com/lostisland/faraday_middleware/blob/main/lib/faraday_middleware/response/rashify.rb)  | [`rash_alt`](https://rubygems.org/gems/rash_alt)     | Make sure to uninstall original `rash` gem to avoid conflict. |
 
 Examples
 --------


### PR DESCRIPTION
Our Code of Conduct includes a note on inclusive language, and changing the name of the default branch is part of upholding that value.

In the GitHub documentation about renames: https://docs.github.com/en/github/administering-a-repository/renaming-a-branch

> When you rename a branch on GitHub, any URLs that contain the old branch name are automatically redirected to the equivalent URL for the renamed branch. Branch protection policies are also updated, as well as the base branch for open pull requests (including those for forks) and draft releases. After the rename is complete, GitHub provides instructions on the repository's home page directing contributors to update their local Git environments.

TODO:

- [ ] Change the name of the default branch in GitHub settings