### PR TITLE
GitHub Actions: use ruby/setup-ruby@v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,35 +36,19 @@ jobs:
   build:
     needs: [linting]
     runs-on: ubuntu-latest
+    fail-fast: false
     strategy:
       matrix:
-        ruby: ['2.4', '2.5', '2.6', '2.7']
+        ruby: ['2.4', '2.5', '2.6', '2.7', '3.0']
 
     steps:
     - uses: actions/checkout@v1
-
-    - name: Install dependencies
-      run: |
-        sudo apt-get install libcurl4-openssl-dev
-
-    - name: Set up RVM
-      run: |
-        curl -sSL https://get.rvm.io | bash
-
-    - name: Set up Ruby
-      run: |
-        source $HOME/.rvm/scripts/rvm
-        rvm install ${{ matrix.ruby }} --disable-binary
-        rvm --default use ${{ matrix.ruby }}
-
-    - name: Build
-      run: |
-        source $HOME/.rvm/scripts/rvm
-        sudo apt-get install libcurl4-openssl-dev
-        gem install bundler -v '<2'
-        bundle install --jobs 4 --retry 3
-
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+    - name: Install system dependencies
+      run: sudo apt install libcurl4-openssl-dev
+    - name: Install Ruby dependencies
+      run: bundle install --jobs 4 --retry 3
     - name: Test
-      run: |
-        source $HOME/.rvm/scripts/rvm
-        bundle exec rake
+      run: bundle exec rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,6 @@ jobs:
   build:
     needs: [linting]
     runs-on: ubuntu-latest
-    fail-fast: false
     strategy:
       matrix:
         ruby: ['2.4', '2.5', '2.6', '2.7', '3.0']


### PR DESCRIPTION
This is in order to go faster. Borrowed from the Faraday CI configuration. 

**Result**: From 4 min to 40 s.


Fixes #271