### PR TITLE
Allow users to define its own set of Cacheable Status Code when using Faraday Middleware Cache

### DIFF
--- a/lib/faraday_middleware/response/caching.rb
+++ b/lib/faraday_middleware/response/caching.rb
@@ -26,16 +26,16 @@ module FaradayMiddleware
     #
     # cache   - An object that responds to read and write (default: nil).
     # options - An options Hash (default: {}):
-    #           :ignore_params         - String name or Array names of query
+    #           :ignore_params - String name or Array names of query
     #                                    params that should be ignored when forming
     #                                    the cache key (default: []).
-    #           :write_options         - Hash of settings that should be passed as the
+    #           :write_options - Hash of settings that should be passed as the
     #                                    third options parameter to the cache's #write
     #                                    method. If not specified, no options parameter
     #                                    will be passed.
-    #           :full_key              - Boolean - use full URL as cache key:
+    #           :full_key      - Boolean - use full URL as cache key:
     #                                    (url.host + url.request_uri)
-    #           :cacheable_status_code - Array of http status code to be cache
+    #           :status_codes  - Array of http status code to be cache
     #                                    (default: CACHEABLE_STATUS_CODE)
     #
     # Yields if no cache is given. The block should return a cache object.
@@ -89,7 +89,7 @@ module FaradayMiddleware
     end
 
     def custom_status_codes
-      @custom_status_codes ||= CACHEABLE_STATUS_CODES & Array(@options[:cacheable_status_code]).map(&:to_i)
+      @custom_status_codes ||= CACHEABLE_STATUS_CODES & Array(@options[:status_codes]).map(&:to_i)
       @custom_status_codes.any? ? @custom_status_codes : CACHEABLE_STATUS_CODES
     end
 

--- a/lib/faraday_middleware/response/caching.rb
+++ b/lib/faraday_middleware/response/caching.rb
@@ -90,9 +90,9 @@ module FaradayMiddleware
 
     def custom_status_codes
       @custom_status_codes ||= begin
-                                 codes = CACHEABLE_STATUS_CODES & Array(@options[:status_codes]).map(&:to_i)
-                                 codes.any? ? codes : CACHEABLE_STATUS_CODES
-                               end
+        codes = CACHEABLE_STATUS_CODES & Array(@options[:status_codes]).map(&:to_i)
+        codes.any? ? codes : CACHEABLE_STATUS_CODES
+      end
     end
 
     def cache_on_complete(env)

--- a/lib/faraday_middleware/response/caching.rb
+++ b/lib/faraday_middleware/response/caching.rb
@@ -89,8 +89,10 @@ module FaradayMiddleware
     end
 
     def custom_status_codes
-      @custom_status_codes ||= CACHEABLE_STATUS_CODES & Array(@options[:status_codes]).map(&:to_i)
-      @custom_status_codes.any? ? @custom_status_codes : CACHEABLE_STATUS_CODES
+      @custom_status_codes ||= begin
+                                 codes = CACHEABLE_STATUS_CODES & Array(@options[:status_codes]).map(&:to_i)
+                                 codes.any? ? codes : CACHEABLE_STATUS_CODES
+                               end
     end
 
     def cache_on_complete(env)

--- a/lib/faraday_middleware/response/caching.rb
+++ b/lib/faraday_middleware/response/caching.rb
@@ -26,15 +26,17 @@ module FaradayMiddleware
     #
     # cache   - An object that responds to read and write (default: nil).
     # options - An options Hash (default: {}):
-    #           :ignore_params - String name or Array names of query
-    #                            params that should be ignored when forming
-    #                            the cache key (default: []).
-    #           :write_options - Hash of settings that should be passed as the
-    #                            third options parameter to the cache's #write
-    #                            method. If not specified, no options parameter
-    #                            will be passed.
-    #           :full_key      - Boolean - use full URL as cache key:
-    #                            (url.host + url.request_uri)
+    #           :ignore_params         - String name or Array names of query
+    #                                    params that should be ignored when forming
+    #                                    the cache key (default: []).
+    #           :write_options         - Hash of settings that should be passed as the
+    #                                    third options parameter to the cache's #write
+    #                                    method. If not specified, no options parameter
+    #                                    will be passed.
+    #           :full_key              - Boolean - use full URL as cache key:
+    #                                    (url.host + url.request_uri)
+    #           :cacheable_status_code - Array of http status code to be cache
+    #                                    (default: CACHEABLE_STATUS_CODE)
     #
     # Yields if no cache is given. The block should return a cache object.
     def initialize(app, cache = nil, options = {})

--- a/spec/unit/caching_spec.rb
+++ b/spec/unit/caching_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe FaradayMiddleware::Caching do
   end
 
   context ':cacheable_status_code' do
-    let(:options) { { cacheable_status_code: %w[404] } }
+    let(:options) { { status_codes: %w[404] } }
 
     it 'caches requests based on defined cacheable_status_code' do
       expect(get('/').body).to eq('request:1')
@@ -110,7 +110,7 @@ RSpec.describe FaradayMiddleware::Caching do
     end
 
     context 'with invalid :cacheable_status_code status' do
-      let(:options) { { cacheable_status_code: %w[404,500] } }
+      let(:options) { { status_codes: %w[404,500] } }
 
       it 'caches requests based on valid defined cacheable_status_code' do
         expect(get('/not_found').body).to eq('request:1')
@@ -121,7 +121,7 @@ RSpec.describe FaradayMiddleware::Caching do
     end
 
     context 'with no valid :cacheable_status_code status' do
-      let(:options) { { cacheable_status_code: %w[500] } }
+      let(:options) { { status_codes: %w[500] } }
       it 'caches requests based on default cacheable_status_code' do
         expect(get('/').body).to eq('request:1')
         expect(get('/broken').body).to eq('request:2')


### PR DESCRIPTION
This implementation allows users to define its own set of status codes for caching as opposed to sticking to a set of predefined CACHEABLE_STATUS_CODE constant. Nonetheless, user defined status code has to be within the list of predefined CACHEABLE_STATUS_CODE constant.