### PR TITLE
fix: drop unused addressable gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ group :development do
 end
 
 group :test do
-  gem 'addressable', '< 2.4'
   gem 'rspec', '>= 3'
   gem 'simplecov', '~> 0.12.0'
   gem 'webmock', '~> 2.3'


### PR DESCRIPTION
While reading about a ReDOS in addressable, I learned that this repository no longer uses the gem.

Removing from Gemfile.