### PR TITLE
Configurable JSON encoders and decoders

### DIFF
--- a/lib/faraday_middleware/request/encode_json.rb
+++ b/lib/faraday_middleware/request/encode_json.rb
@@ -27,7 +27,13 @@ module FaradayMiddleware
     end
 
     def encode(data)
-      ::JSON.generate data
+      if options[:encoder].is_a?(Array) && options[:encoder].size >= 2
+        options[:encoder][0].public_send(options[:encoder][1], data)
+      elsif options[:encoder].respond_to?(:encode)
+        options[:encoder].encode(data)
+      else
+        ::JSON.dump data
+      end
     end
 
     def match_content_type(env)

--- a/lib/faraday_middleware/request/encode_json.rb
+++ b/lib/faraday_middleware/request/encode_json.rb
@@ -32,7 +32,7 @@ module FaradayMiddleware
       elsif options[:encoder].respond_to?(:encode)
         options[:encoder].encode(data)
       else
-        ::JSON.dump data
+        ::JSON.generate data
       end
     end
 

--- a/spec/unit/encode_json_spec.rb
+++ b/spec/unit/encode_json_spec.rb
@@ -108,4 +108,68 @@ RSpec.describe FaradayMiddleware::EncodeJson do
       expect(result_type).to eq('application/xml; charset=utf-8')
     end
   end
+
+  context 'with encoder' do
+    let(:encoder) do
+      double('Encoder').tap do |e|
+        allow(e).to receive(:encode) { |s, opts| JSON.generate(s, opts) }
+      end
+    end
+
+    let(:result) { process(a: 1) }
+
+    context 'when encoder is passed as object' do
+      let(:middleware) { described_class.new(->(env) { env }, { encoder: encoder }) }
+
+      it 'calls specified JSON encoder' do
+        expect(encoder).to receive(:encode).with({ a: 1 })
+
+        result
+      end
+
+      it 'encodes body' do
+        expect(result_body).to eq('{"a":1}')
+      end
+
+      it 'adds content type' do
+        expect(result_type).to eq('application/json')
+      end
+    end
+
+    context 'when encoder is passed as an object-method pair' do
+      let(:middleware) { described_class.new(->(env) { env }, { encoder: [encoder, :encode] }) }
+
+      it 'calls specified JSON encoder' do
+        expect(encoder).to receive(:encode).with({ a: 1 })
+
+        result
+      end
+
+      it 'encodes body' do
+        expect(result_body).to eq('{"a":1}')
+      end
+
+      it 'adds content type' do
+        expect(result_type).to eq('application/json')
+      end
+    end
+
+    context 'when encoder is not passed' do
+      let(:middleware) { described_class.new(->(env) { env }) }
+
+      it 'calls JSON.generate' do
+        expect(JSON).to receive(:generate).with({ a: 1 }, a_kind_of(Hash))
+
+        result
+      end
+
+      it 'encodes body' do
+        expect(result_body).to eq('{"a":1}')
+      end
+
+      it 'adds content type' do
+        expect(result_type).to eq('application/json')
+      end
+    end
+  end
 end

--- a/spec/unit/encode_json_spec.rb
+++ b/spec/unit/encode_json_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe FaradayMiddleware::EncodeJson do
       let(:middleware) { described_class.new(->(env) { env }) }
 
       it 'calls JSON.generate' do
-        expect(JSON).to receive(:generate).with({ a: 1 }, a_kind_of(Hash))
+        expect(JSON).to receive(:generate).with({ a: 1 })
 
         result
       end

--- a/spec/unit/parse_json_spec.rb
+++ b/spec/unit/parse_json_spec.rb
@@ -136,4 +136,76 @@ RSpec.describe FaradayMiddleware::ParseJson, type: :response do
       expect(response.body).to eq(result)
     end
   end
+
+  context 'with decoder' do
+    let(:decoder) do
+      double('Decoder').tap do |e|
+        allow(e).to receive(:decode) { |s, opts| JSON.parse(s, opts) }
+      end
+    end
+
+    let(:body) { '{"a": 1}' }
+    let(:result) { { a: 1 } }
+
+    context 'when decoder is passed as object' do
+      let(:options) do
+        {
+          parser_options: {
+            decoder: decoder,
+            option: :option_value,
+            symbolize_names: true
+          }
+        }
+      end
+
+      it 'passes relevant options to specified decoder\'s decode method' do
+        expect(decoder).to receive(:decode)
+          .with(body, { option: :option_value, symbolize_names: true })
+          .and_return(result)
+
+        response = process(body)
+        expect(response.body).to eq(result)
+      end
+    end
+
+    context 'when decoder is passed as an object-method pair' do
+      let(:options) do
+        {
+          parser_options: {
+            decoder: [decoder, :decode],
+            option: :option_value,
+            symbolize_names: true
+          }
+        }
+      end
+
+      it 'passes relevant options to specified decoder\'s method' do
+        expect(decoder).to receive(:decode)
+          .with(body, { option: :option_value, symbolize_names: true })
+          .and_return(result)
+
+        response = process(body)
+        expect(response.body).to eq(result)
+      end
+    end
+
+    context 'when decoder is not passed' do
+      let(:options) do
+        {
+          parser_options: {
+            symbolize_names: true
+          }
+        }
+      end
+
+      it 'passes relevant options to JSON parse' do
+        expect(JSON).to receive(:parse)
+          .with(body, { symbolize_names: true })
+          .and_return(result)
+
+        response = process(body)
+        expect(response.body).to eq(result)
+      end
+    end
+  end
 end


### PR DESCRIPTION
By default `FaradayMiddleware::EncodeJson` and `FaradayMiddleware::ParseJson` uses `json` to encode/decode JSON data, although there are gems like `oj` which do the job faster than Ruby's built-in `json`.

This implementation allows to pass `encoder` option to `FaradayMiddleware::EncodeJson` and `decoder` option to pass in `parser_options` to `FaradayMiddleware::ParseJson`

```ruby
require 'oj'

Faraday.new do |conn|
  conn.request :json, encoder: Oj
  conn.response :json, parser_options: { decoder: Oj }
end
```
