### PR TITLE
CI: Trust ruby/setup-ruby to install gems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
     - name: Install system dependencies
-      run: sudo apt install libcurl4-openssl-dev
+      run: sudo apt-get update && sudo apt install libcurl4-openssl-dev
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,10 @@ jobs:
       - name: Rubocop
         run: bundle exec rubocop --format progress
 
+      # Deal with "yard-junk now requires Ruby version >= 2.7.0. The current ruby version is 2.6.10.210."
       - name: Yard-Junk
         run: |
-          gem install yard-junk --no-document
+          gem install yard-junk -v 0.0.9 --no-document
           yard-junk --path lib
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           gem install ostruct
           gem install yard-junk -v 0.0.9 --no-document
-          yard-junk --path lib
+          RUBYOPT='-r ostruct' yard-junk --path lib
 
   build:
     needs: [linting]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       # Deal with "yard-junk now requires Ruby version >= 2.7.0. The current ruby version is 2.6.10.210."
       - name: Yard-Junk
         run: |
+          gem install ostruct
           gem install yard-junk -v 0.0.9 --no-document
           yard-junk --path lib
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,22 +14,19 @@ env:
 jobs:
   linting:
     runs-on: ubuntu-latest
-
+    env:
+      BUNDLE_WITHOUT: 'development test'
+      BUNDLE_WITH: 'lint'
     steps:
-      - uses: actions/checkout@v3
-
+      - uses: actions/checkout@v4
       - name: Set up Ruby 2.6
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.6
+          bundler-cache: true # 'bundle install' and cache gems
 
       - name: Rubocop
-        run: |
-          gem install bundler
-          bundle config set without 'development test'
-          bundle config set with 'lint'
-          bundle install
-          bundle exec rubocop --format progress
+        run: bundle exec rubocop --format progress
 
       - name: Yard-Junk
         run: |
@@ -44,13 +41,12 @@ jobs:
         ruby: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
 
     steps:
-    - uses: actions/checkout@v3
+    - name: Install system dependencies
+      run: sudo apt install libcurl4-openssl-dev
+    - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - name: Install system dependencies
-      run: sudo apt install libcurl4-openssl-dev
-    - name: Install Ruby dependencies
-      run: bundle install --jobs 4 --retry 3
+        bundler-cache: true # 'bundle install' and then cache gems
     - name: Test
       run: bundle exec rake

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Ruby 2.6
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6.x
+          ruby-version: 2.6
 
       - name: Publish to RubyGems
         run: |


### PR DESCRIPTION
This PR changes the test CI setup to use as much knowledge as possible from the setup-ruby GH Action, keeping version number and such out of the file. For the yard-junk lint check, I did some steps.

Perhaps we can stop having the yard-junk check at all, we are not actively working on the docs of this project.